### PR TITLE
fix(command): separate args and commands in commandHandler method

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -54,7 +54,7 @@ func run(cmd *cobra.Command, _ []string) {
 		for _, i := range inputs {
 			args[i] = i
 		}
-		response := botEngine.Run(entity.AppIDCLI, "0", args)
+		response := botEngine.Run(entity.AppIDCLI, "0", []string{}, args)
 
 		cmd.Printf("%v\n%v", response.Title, response.Message)
 	}

--- a/internal/delivery/grpc/robopac.go
+++ b/internal/delivery/grpc/robopac.go
@@ -26,7 +26,7 @@ func (rs *robopacServer) Run(_ context.Context, er *robopac.RunRequest) (*robopa
 		beInput[t] = t
 	}
 
-	res := rs.engine.Run(entity.AppIDgRPC, er.Id, beInput)
+	res := rs.engine.Run(entity.AppIDgRPC, er.Id, nil, beInput)
 
 	return &robopac.RunResponse{
 		Response: res.Message,

--- a/internal/delivery/http/http.go
+++ b/internal/delivery/http/http.go
@@ -58,7 +58,7 @@ func (hh *HTTPHandler) Run(c echo.Context) error {
 		beInput[t] = t
 	}
 
-	cmdResult := hh.engine.Run(entity.AppIDHTTP, c.RealIP(), beInput)
+	cmdResult := hh.engine.Run(entity.AppIDHTTP, c.RealIP(), nil, beInput)
 
 	return c.JSON(http.StatusOK, RunResponse{
 		Result: cmdResult.Message,

--- a/internal/platforms/discord/discord.go
+++ b/internal/platforms/discord/discord.go
@@ -71,7 +71,7 @@ func (bot *DiscordBot) deleteAllCommands() {
 
 func (bot *DiscordBot) registerCommands() error {
 	bot.Session.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
-		bot.commandHandler(bot, s, i)
+		bot.commandHandler(s, i)
 	})
 
 	beCmds := bot.engine.Commands()
@@ -180,50 +180,49 @@ func (bot *DiscordBot) registerCommands() error {
 	return nil
 }
 
-func (bot *DiscordBot) commandHandler(db *DiscordBot, s *discordgo.Session, i *discordgo.InteractionCreate) {
+func (bot *DiscordBot) commandHandler(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	if i.GuildID != bot.cfg.GuildID {
 		bot.respondErrMsg("Please send messages on server chat", s, i)
 		return
 	}
 
-	// Get the application command data
+	var commands []string
 	args := make(map[string]string)
-	rootCmd := i.ApplicationCommandData()
-	args[rootCmd.Name] = rootCmd.Name
-	for _, opt := range rootCmd.Options {
-		args = parseCmdOption(&rootCmd, opt, args)
+
+	// Get the application command data
+	discordCmd := i.ApplicationCommandData()
+	commands = append(commands, discordCmd.Name)
+	for _, opt := range discordCmd.Options {
+		if opt.Type == discordgo.ApplicationCommandOptionSubCommand {
+			commands = append(commands, opt.Name)
+			for _, o := range opt.Options {
+				args = parseArgs(&discordCmd, o, args)
+			}
+		}
 	}
 
-	res := db.engine.Run(entity.AppIDDiscord, i.Member.User.ID, args)
+	res := bot.engine.Run(entity.AppIDDiscord, i.Member.User.ID, commands, args)
 	bot.respondResultMsg(res, s, i)
 }
 
-func parseCmdOption(
+func parseArgs(
 	rootCmd *discordgo.ApplicationCommandInteractionData,
 	opt *discordgo.ApplicationCommandInteractionDataOption,
 	result map[string]string,
 ) map[string]string {
-	if opt.Type == discordgo.ApplicationCommandOptionSubCommand {
-		result[opt.Name] = opt.Name
-	}
-
-	for _, o := range opt.Options {
-		//nolint
-		switch o.Type {
-		case discordgo.ApplicationCommandOptionSubCommand:
-			return parseCmdOption(rootCmd, o, result)
-		case discordgo.ApplicationCommandOptionString:
-			result[o.Name] = o.StringValue()
-		case discordgo.ApplicationCommandOptionInteger:
-			result[o.Name] = strconv.Itoa(int(o.IntValue()))
-		case discordgo.ApplicationCommandOptionNumber:
-			v := strconv.FormatFloat(o.FloatValue(), 'f', 10, 64)
-			result[o.Name] = v
-		case discordgo.ApplicationCommandOptionAttachment:
-			// TODO: handle multiple attachment
-			for _, attachment := range rootCmd.Resolved.Attachments {
-				result[o.Name] = attachment.URL
-			}
+	//nolint
+	switch opt.Type {
+	case discordgo.ApplicationCommandOptionString:
+		result[opt.Name] = opt.StringValue()
+	case discordgo.ApplicationCommandOptionInteger:
+		result[opt.Name] = strconv.Itoa(int(opt.IntValue()))
+	case discordgo.ApplicationCommandOptionNumber:
+		v := strconv.FormatFloat(opt.FloatValue(), 'f', 10, 64)
+		result[opt.Name] = v
+	case discordgo.ApplicationCommandOptionAttachment:
+		// TODO: handle multiple attachment
+		for _, attachment := range rootCmd.Resolved.Attachments {
+			result[opt.Name] = attachment.URL
 		}
 	}
 

--- a/internal/platforms/telegram/telegram.go
+++ b/internal/platforms/telegram/telegram.go
@@ -103,7 +103,8 @@ func (bot *TelegramBot) HandleUpdate(b *gotgbot.Bot, ctx *ext.Context) error {
 		}
 
 		// Pass the array to the bot engine.
-		res := bot.botEngine.Run(entity.AppIDTelegram, strconv.FormatInt(ctx.EffectiveSender.User.Id, 10), beInput)
+		callerID := strconv.FormatInt(ctx.EffectiveSender.User.Id, 10)
+		res := bot.botEngine.Run(entity.AppIDTelegram, callerID, []string{}, beInput)
 
 		// Check if the command execution resulted in an error.
 		if res.Error != "" {


### PR DESCRIPTION
## Description
input commands and arguments are now separated in commandHandler to avoid fault parsing error. In this PR commands are parsed into []string not map[string].

## Types of changes
- [X] Bug fix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (corrections, enhancements, or additions to documentation)
- [ ] Other (please describe):
