### PR TITLE
ci: add extra host to composer

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -3,9 +3,10 @@ FROM golang:1.23.3-alpine AS builder
 RUN apk add --no-cache bash make
 WORKDIR /pagu
 COPY .. .
-RUN make build-discord build-telegram
+RUN make build
 
 FROM alpine:3.14 AS pagu
 WORKDIR /bin
+COPY --from=builder /pagu/build/pagu-cli .
 COPY --from=builder /pagu/build/pagu-discord .
 COPY --from=builder /pagu/build/pagu-telegram .

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - pagu_phpmyadmin
     volumes:
       - ${HOME}/pagu:/pagu
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   pagu_discord_staging:
     image: pagu:latest
@@ -51,22 +53,26 @@ services:
       - pagu_phpmyadmin
     volumes:
       - ${HOME}/pagu:/pagu
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
-  pagu_discord_testnet:
+  pagu_discord_moderator:
     image: pagu:stable
-    container_name: pagu_discord_testnet
-    command: "./pagu-discord -c /pagu/config_discord_testnet.yml run"
+    container_name: pagu_discord_moderator
+    command: "./pagu-discord -c /pagu/config_discord_moderator.yml run"
     networks:
       pagu_network:
     depends_on:
       - pagu_phpmyadmin
     volumes:
       - ${HOME}/pagu:/pagu
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
-  pagu_discord_moderator:
+  pagu_discord_testnet:
     image: pagu:stable
-    container_name: pagu_discord_moderator
-    command: "./pagu-discord -c /pagu/config_discord_moderator.yml run"
+    container_name: pagu_discord_testnet
+    command: "./pagu-discord -c /pagu/config_discord_testnet.yml run"
     networks:
       pagu_network:
     depends_on:
@@ -84,6 +90,8 @@ services:
       - pagu_phpmyadmin
     volumes:
       - ${HOME}/pagu:/pagu
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
 volumes:
   pagu-volume:


### PR DESCRIPTION
## Description

This PR adds an extra host, `host.docker.internal`, for Docker containers and also adds `pagu-cli` to the Dockerfile.

Some explanatory links:
- https://stackoverflow.com/questions/24319662/from-inside-of-a-docker-container-how-do-i-connect-to-the-localhost-of-the-mach
- https://dev.to/mjnaderi/accessing-host-services-from-docker-containers-1a97

## Types of changes
- [x] Bug fix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (corrections, enhancements, or additions to documentation)
- [ ] Other (please describe):
