### PR TITLE
fix: ensure set propoer sub-command name

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -191,7 +191,7 @@ func (be *BotEngine) executeCommand(
 	commands []string,
 	args map[string]string,
 ) command.CommandResult {
-	log.Debug("run command", "callerID", callerID, "commands", args, "inputs", args)
+	log.Debug("execute command", "callerID", callerID, "commands", commands, "args", args)
 
 	cmd := be.getTargetCommand(commands)
 	if !cmd.HasAppID(appID) {

--- a/internal/platforms/discord/discord.go
+++ b/internal/platforms/discord/discord.go
@@ -207,8 +207,8 @@ func (bot *Bot) commandHandler(s *discordgo.Session, i *discordgo.InteractionCre
 
 	for _, opt := range discordCmd.Options {
 		if opt.Type == discordgo.ApplicationCommandOptionSubCommand {
-			inputBuilder.WriteString(opt.Name)
 			inputBuilder.WriteString(" ")
+			inputBuilder.WriteString(opt.Name)
 
 			for _, o := range opt.Options {
 				args = parseArgs(&discordCmd, o, args)

--- a/internal/platforms/discord/discord.go
+++ b/internal/platforms/discord/discord.go
@@ -207,8 +207,9 @@ func (bot *Bot) commandHandler(s *discordgo.Session, i *discordgo.InteractionCre
 
 	for _, opt := range discordCmd.Options {
 		if opt.Type == discordgo.ApplicationCommandOptionSubCommand {
+			inputBuilder.WriteString(opt.Name)
 			inputBuilder.WriteString(" ")
-			inputBuilder.WriteString(discordCmd.Name)
+
 			for _, o := range opt.Options {
 				args = parseArgs(&discordCmd, o, args)
 			}


### PR DESCRIPTION
## Description

This PR fixes an issue where the command name is repeated instead of using the sub-command name. For example:  
`calculate calculate --stake=1000.0000000000 --days=1`  
should be:  
`calculate reward --stake=1000.0000000000 --days=1`

## Types of changes
- [x] Bug fix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (corrections, enhancements, or additions to documentation)
- [ ] Other (please describe):
