### PR TITLE
chore: bump version to 0.0.2

### DIFF
--- a/version.go
+++ b/version.go
@@ -11,7 +11,7 @@ type Version struct {
 var version = Version{
 	Major: 0,
 	Minor: 0,
-	Patch: 1,
+	Patch: 2,
 }
 
 func StringVersion() string {


### PR DESCRIPTION
## Description
Bumping Pagu version after releasing latest stable one

## Types of changes
- [ ] Bug fix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (corrections, enhancements, or additions to documentation)
- [x] Other (please describe): new version (v0.0.2)
