### PR TITLE
fix: target name for Discord/Telegram bots

### DIFF
--- a/config/global.go
+++ b/config/global.go
@@ -5,8 +5,7 @@ const (
 )
 
 const (
-	BotNamePaguMainnet   = "Pagu-Mainnet"
-	BotNamePaguStaging   = "Pagu-Staging"
+	BotNamePaguMainnet   = "Pagu"
 	BotNamePaguTestnet   = "Pagu-Testnet"
 	BotNamePaguModerator = "Pagu-Moderator"
 )

--- a/internal/platforms/discord/discord.go
+++ b/internal/platforms/discord/discord.go
@@ -88,8 +88,7 @@ func (bot *Bot) registerCommands() error {
 		}
 
 		switch bot.target {
-		case config.BotNamePaguMainnet,
-			config.BotNamePaguStaging:
+		case config.BotNamePaguMainnet:
 			if !utils.IsFlagSet(cmd.TargetFlag, command.TargetMaskMainnet) {
 				continue
 			}
@@ -103,6 +102,10 @@ func (bot *Bot) registerCommands() error {
 			if !utils.IsFlagSet(cmd.TargetFlag, command.TargetMaskModerator) {
 				continue
 			}
+
+		default:
+			log.Warn("invalid target", "target", bot.target)
+			continue
 		}
 
 		log.Info("registering new command", "name", cmd.Name, "desc", cmd.Help, "index", i, "object", cmd)
@@ -130,6 +133,10 @@ func (bot *Bot) registerCommands() error {
 					if !utils.IsFlagSet(subCmd.TargetFlag, command.TargetMaskModerator) {
 						continue
 					}
+
+				default:
+					log.Warn("invalid target", "target", bot.target)
+					continue
 				}
 
 				log.Info("adding sub-command", "command", cmd.Name,

--- a/internal/platforms/discord/discord.go
+++ b/internal/platforms/discord/discord.go
@@ -105,6 +105,7 @@ func (bot *Bot) registerCommands() error {
 
 		default:
 			log.Warn("invalid target", "target", bot.target)
+
 			continue
 		}
 
@@ -136,6 +137,7 @@ func (bot *Bot) registerCommands() error {
 
 				default:
 					log.Warn("invalid target", "target", bot.target)
+
 					continue
 				}
 

--- a/internal/platforms/telegram/telegram.go
+++ b/internal/platforms/telegram/telegram.go
@@ -117,6 +117,7 @@ func (bot *Bot) registerCommands() error {
 
 		default:
 			log.Warn("invalid target", "target", bot.target)
+
 			continue
 		}
 
@@ -147,6 +148,7 @@ func (bot *Bot) registerCommands() error {
 
 				default:
 					log.Warn("invalid target", "target", bot.target)
+
 					continue
 				}
 

--- a/internal/platforms/telegram/telegram.go
+++ b/internal/platforms/telegram/telegram.go
@@ -109,6 +109,15 @@ func (bot *Bot) registerCommands() error {
 			if !utils.IsFlagSet(beCmd.TargetFlag, command.TargetMaskTestnet) {
 				continue
 			}
+
+		case config.BotNamePaguModerator:
+			if !utils.IsFlagSet(beCmd.TargetFlag, command.TargetMaskModerator) {
+				continue
+			}
+
+		default:
+			log.Warn("invalid target", "target", bot.target)
+			continue
 		}
 
 		log.Info("registering new command", "name", beCmd.Name, "desc", beCmd.Help, "index", i, "object", beCmd)
@@ -135,6 +144,10 @@ func (bot *Bot) registerCommands() error {
 					if !utils.IsFlagSet(sCmd.TargetFlag, command.TargetMaskModerator) {
 						continue
 					}
+
+				default:
+					log.Warn("invalid target", "target", bot.target)
+					continue
 				}
 
 				log.Info("adding command sub-command", "command", beCmd.Name,


### PR DESCRIPTION
## Description

Ensure moderator commands won't be deployed on mainnet bots

## Types of changes
- [x] Bug fix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (corrections, enhancements, or additions to documentation)
- [ ] Other (please describe):
