### PR TITLE
fix: use backticks for templates

### DIFF
--- a/internal/engine/command/command.go
+++ b/internal/engine/command/command.go
@@ -174,7 +174,7 @@ func (*Command) executeTemplate(templateContent string, data map[string]any) str
 		},
 	}
 
-	templateContent = strings.Replace(templateContent, "”", "`", -1)
+	templateContent = strings.ReplaceAll(templateContent, "”", "`")
 	tmpl, err := template.New("template").Funcs(funcMap).Parse(templateContent)
 	if err != nil {
 		log.Error("unable to parse template", "error", err)

--- a/internal/engine/command/command.go
+++ b/internal/engine/command/command.go
@@ -281,7 +281,7 @@ func (cmd *Command) AddHelpSubCommand() {
 
 func (cmd *Command) AddAboutSubCommand() {
 	const aboutTemplate = `
-## About Pagu
+**About Pagu**
 
 Version : {{.version}}
 `

--- a/internal/engine/command/command.go
+++ b/internal/engine/command/command.go
@@ -174,6 +174,7 @@ func (*Command) executeTemplate(templateContent string, data map[string]any) str
 		},
 	}
 
+	templateContent = strings.Replace(templateContent, "”", "`", -1)
 	tmpl, err := template.New("template").Funcs(funcMap).Parse(templateContent)
 	if err != nil {
 		log.Error("unable to parse template", "error", err)
@@ -230,7 +231,7 @@ func (cmd *Command) RenderHelpTemplate() CommandResult {
 
 **Available subcommands:**
    {{- range .cmd.SubCommands }}
-   <pre>{{.Name | fixed 15 }}</pre> {{.Emoji}} {{.Help}}
+   ”{{.Name | fixed 15 }}” {{.Emoji}} {{.Help}}
    {{- end}}
 
 Use "{{.cmd.Name}} help --subcommand=[subcommand]" for more information about a subcommand.


### PR DESCRIPTION
## Description

Use ” ([double prime](https://symbl.cc/en/02BA/)) instead ` ([Letter Grave](https://symbl.cc/en/02CB/)) for making block code
 
## Types of changes
- [x] Bug fix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (corrections, enhancements, or additions to documentation)
- [ ] Other (please describe):
