### PR TITLE
feat: add Phoenix command to Pagu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,5 @@ jobs:
 
       - name: Unit tests
         run: make test
+        env:
+          GITHUB_FAUCET_SECRET: ${{ secrets.FAUCET_SECRET }}

--- a/config/config.go
+++ b/config/config.go
@@ -4,24 +4,24 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pagu-project/pagu/pkg/amount"
+	"github.com/pagu-project/pagu/internal/engine/command/phoenix"
 	"github.com/pagu-project/pagu/pkg/log"
 	"github.com/pagu-project/pagu/pkg/nowpayments"
 	"github.com/pagu-project/pagu/pkg/utils"
+	"github.com/pagu-project/pagu/pkg/wallet"
 	"gopkg.in/yaml.v3"
 )
 
 type Config struct {
 	BotName      string              `yaml:"bot_name"`
-	Network      string              `yaml:"network"`
 	NetworkNodes []string            `yaml:"network_nodes"`
 	LocalNode    string              `yaml:"local_node"`
 	Database     Database            `yaml:"database"`
 	GRPC         *GRPC               `yaml:"grpc"` // ! TODO: config for modules should moved to the module.
-	Wallet       *Wallet             `yaml:"wallet"`
+	Wallet       *wallet.Config      `yaml:"wallet"`
 	Logger       *log.Config         `yaml:"logger"`
 	HTTP         *HTTP               `yaml:"http"`
-	Phoenix      *PhoenixNetwork     `yaml:"phoenix"`
+	Phoenix      *phoenix.Config     `yaml:"phoenix"`
 	Discord      *DiscordBot         `yaml:"discord"`
 	Telegram     *Telegram           `yaml:"telegram"`
 	Notification *Notification       `yaml:"notification"`
@@ -30,13 +30,6 @@ type Config struct {
 
 type Database struct {
 	URL string `yaml:"url"`
-}
-
-type Wallet struct {
-	Address  string        `yaml:"address"`
-	Path     string        `yaml:"path"`
-	Password string        `yaml:"password"`
-	Fee      amount.Amount `yaml:"fee"`
 }
 
 type DiscordBot struct {
@@ -50,10 +43,6 @@ type GRPC struct {
 
 type HTTP struct {
 	Listen string `yaml:"listen"`
-}
-
-type PhoenixNetwork struct {
-	FaucetAmount amount.Amount `yaml:"faucet_amount"`
 }
 
 type Telegram struct {

--- a/config/config.sample.yml
+++ b/config/config.sample.yml
@@ -1,8 +1,5 @@
 bot_name: "Pagu-Development"
 
-# Specify the network the bot will use: Mainnet, Testnet, or Localnet.
-network: "Mainnet"
-
 # Pactus clients
 local_node: "bootstrap1.pactus.org:50051" # Address of the local Pactus node for direct communication.
 

--- a/config/config.sample.yml
+++ b/config/config.sample.yml
@@ -36,8 +36,15 @@ wallet:
 
 # Phoenix (TestNet) configuration
 phoenix:
-  # Number of coins to send when the faucet is used.
+  # A node in Phoenix Tesnet network
+  client: "testnet1.pactus.org:50052"
+
+  # The private key to sign the faucet message
+  private_key: "TSECRET1RZSMS2JGNFLRU26NHNQK3JYTD4KGKLGW4S7SG75CZ057SR7CE8HUSG5MS3Z"
+
   faucet_amount: 5
+  faucet_fee: 0.01
+  faucet_cooldown: "24h"
 
 # Database configuration
 database:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"testing"
 
+	"github.com/pagu-project/pagu/internal/engine/command/phoenix"
+	"github.com/pagu-project/pagu/pkg/wallet"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +22,7 @@ func TestBasicCheck(t *testing.T) {
 		{
 			name: "Valid config",
 			cfg: Config{
-				Wallet: &Wallet{
+				Wallet: &wallet.Config{
 					Address:  "test_wallet_address",
 					Path:     tempWalletPath, // Use the temporary directory
 					Password: "test_password",
@@ -30,14 +32,14 @@ func TestBasicCheck(t *testing.T) {
 					Token:   "MTEabc123",
 					GuildID: "123456789",
 				},
-				Phoenix: &PhoenixNetwork{},
+				Phoenix: &phoenix.Config{},
 			},
 			wantErr: false,
 		},
 		{
 			name: "Invalid RPCNodes",
 			cfg: Config{
-				Wallet: &Wallet{
+				Wallet: &wallet.Config{
 					Address:  "test_wallet_address",
 					Path:     "/valid/path",
 					Password: "test_password",

--- a/config/global.go
+++ b/config/global.go
@@ -6,6 +6,5 @@ const (
 
 const (
 	BotNamePaguMainnet   = "Pagu"
-	BotNamePaguTestnet   = "Pagu-Testnet"
 	BotNamePaguModerator = "Pagu-Moderator"
 )

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  pagu_discord_mainnet:
+  pagu_discord:
     image: pagu:${DEPLOY_TAG}
     container_name: pagu_discord_mainnet_${DEPLOY_TAG}
     command: "./pagu-discord -c /pagu/config_discord_mainnet.${DEPLOY_TAG}.yml run"
@@ -10,7 +10,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
-  pagu_discord_moderator:
+  pagu_moderator:
     image: pagu:${DEPLOY_TAG}
     container_name: pagu_discord_moderator_${DEPLOY_TAG}
     command: "./pagu-discord -c /pagu/config_discord_moderator.${DEPLOY_TAG}.yml run"
@@ -21,16 +21,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
-  pagu_discord_testnet:
-    image: pagu:${DEPLOY_TAG}
-    container_name: pagu_discord_testnet_${DEPLOY_TAG}
-    command: "./pagu-discord -c /pagu/config_discord_testnet.${DEPLOY_TAG}.yml run"
-    networks:
-      - pagu_network
-    volumes:
-      - ${HOME}/pagu:/pagu
-
-  pagu_telegram_mainnet:
+  pagu_telegram:
     image: pagu:${DEPLOY_TAG}
     container_name: pagu_telegram_mainnet_${DEPLOY_TAG}
     command: "./pagu-telegram -c /pagu/config_telegram_mainnet.${DEPLOY_TAG}.yml run"

--- a/internal/engine/command/command.go
+++ b/internal/engine/command/command.go
@@ -24,10 +24,9 @@ const errorTemplate = `
 
 var (
 	TargetMaskMainnet   = 1
-	TargetMaskTestnet   = 2
-	TargetMaskModerator = 4
+	TargetMaskModerator = 2
 
-	TargetMaskAll = TargetMaskMainnet | TargetMaskTestnet | TargetMaskModerator
+	TargetMaskAll = TargetMaskMainnet | TargetMaskModerator
 )
 
 type InputBox int

--- a/internal/engine/command/crowdfund/config.go
+++ b/internal/engine/command/crowdfund/config.go
@@ -1,5 +1,5 @@
 package crowdfund
 
 type Config struct {
-	ActiveCampaignID uint
+	// Nothing for now, Maybe in future
 }

--- a/internal/engine/command/network/network.gen.go
+++ b/internal/engine/command/network/network.gen.go
@@ -32,13 +32,13 @@ func (c *NetworkCmd) buildSubCmds() *networkSubCmds {
 		Name:           "health",
 		Help:           "Check the network health status",
 		Handler:        c.healthHandler,
-		ResultTemplate: "Network is {{.Status}}\nCurrentTime: {{.CurrentTime}}\nLastBlockTime: {{.LastBlockTime}}\nTime Diff: {{.TimeDiff}}\nLast Block Height: {{.LastBlockHeight}}\n",
+		ResultTemplate: "Network is {{.Status}}\nCurrent Time: {{.CurrentTime}}\nLast Block Time: {{.LastBlockTime}}\nTime Difference: {{.TimeDiff}}\nLast Block Height: {{.LastBlockHeight}}\n",
 	}
 	subCmdStatus := &command.Command{
 		Name:           "status",
 		Help:           "View network statistics",
 		Handler:        c.statusHandler,
-		ResultTemplate: "Network Name: {{.NetworkName}}\nConnected Peers: {{.ConnectedPeers}}\nValidators Count: {{.ValidatorsCount}}\nAccounts Count: {{.AccountsCount}}\nCurrent Block Height: {{.CurrentBlockHeight}}\nTotal Power: {{.TotalPower}} PAC\nTotal Committee Power: {{.TotalCommitteePower}} PAC\nCirculating Supply: {{.CirculatingSupply}} PAC\n\n> Note📝: This info is from one random network node. Non-calculator data may not be consistent.\n",
+		ResultTemplate: "Network Name: {{.NetworkName}}\nConnected Peers: {{.ConnectedPeers}}\nValidator Count: {{.ValidatorsCount}}\nAccount Count: {{.AccountsCount}}\nCurrent Block Height: {{.CurrentBlockHeight}}\nTotal Power: {{.TotalPower}} PAC\nTotal Committee Power: {{.TotalCommitteePower}} PAC\nCirculating Supply: {{.CirculatingSupply}} PAC\n\n> Note📝: This info is from one random network node. Some data may not be consistent.\n",
 	}
 
 	return &networkSubCmds{

--- a/internal/engine/command/network/network.yml
+++ b/internal/engine/command/network/network.yml
@@ -34,6 +34,7 @@ sub_commands:
       LastBlockTime: {{.LastBlockTime}}
       Time Diff: {{.TimeDiff}}
       Last Block Height: {{.LastBlockHeight}}
+
   - name: status
     help: View network statistics
     result_template: |

--- a/internal/engine/command/network/network.yml
+++ b/internal/engine/command/network/network.yml
@@ -26,25 +26,27 @@ sub_commands:
         input_box: Text
         optional: false
 
+  # In case you update this message, please update the phoenix message as well.
   - name: health
     help: Check the network health status
     result_template: |
       Network is {{.Status}}
-      CurrentTime: {{.CurrentTime}}
-      LastBlockTime: {{.LastBlockTime}}
-      Time Diff: {{.TimeDiff}}
+      Current Time: {{.CurrentTime}}
+      Last Block Time: {{.LastBlockTime}}
+      Time Difference: {{.TimeDiff}}
       Last Block Height: {{.LastBlockHeight}}
 
+  # In case you update this message, please update the phoenix message as well.
   - name: status
     help: View network statistics
     result_template: |
       Network Name: {{.NetworkName}}
       Connected Peers: {{.ConnectedPeers}}
-      Validators Count: {{.ValidatorsCount}}
-      Accounts Count: {{.AccountsCount}}
+      Validator Count: {{.ValidatorsCount}}
+      Account Count: {{.AccountsCount}}
       Current Block Height: {{.CurrentBlockHeight}}
       Total Power: {{.TotalPower}} PAC
       Total Committee Power: {{.TotalCommitteePower}} PAC
       Circulating Supply: {{.CirculatingSupply}} PAC
 
-      > Note📝: This info is from one random network node. Non-calculator data may not be consistent.
+      > Note📝: This info is from one random network node. Some data may not be consistent.

--- a/internal/engine/command/phoenix/config.go
+++ b/internal/engine/command/phoenix/config.go
@@ -1,0 +1,12 @@
+package phoenix
+
+import (
+	"github.com/pactus-project/pactus/crypto/ed25519"
+	"github.com/pagu-project/pagu/pkg/amount"
+)
+
+type Config struct {
+	Client       string              `yaml:"client"`
+	PrivateKey   *ed25519.PrivateKey `yaml:"private_key"`
+	FaucetAmount amount.Amount       `yaml:"faucet_amount"`
+}

--- a/internal/engine/command/phoenix/config.go
+++ b/internal/engine/command/phoenix/config.go
@@ -1,12 +1,15 @@
 package phoenix
 
 import (
-	"github.com/pactus-project/pactus/crypto/ed25519"
+	"time"
+
 	"github.com/pagu-project/pagu/pkg/amount"
 )
 
 type Config struct {
-	Client       string              `yaml:"client"`
-	PrivateKey   *ed25519.PrivateKey `yaml:"private_key"`
-	FaucetAmount amount.Amount       `yaml:"faucet_amount"`
+	Client         string        `yaml:"client"`
+	PrivateKey     string        `yaml:"private_key"`
+	FaucetAmount   amount.Amount `yaml:"faucet_amount"`
+	FaucetFee      amount.Amount `yaml:"faucet_fee"`
+	FaucetCooldown time.Duration `yaml:"faucet_cooldown"`
 }

--- a/internal/engine/command/phoenix/faucet.go
+++ b/internal/engine/command/phoenix/faucet.go
@@ -12,7 +12,7 @@ func (c *PhoenixCmd) faucetHandler(
 	cmd *command.Command,
 	args map[string]string,
 ) command.CommandResult {
-	if len(args) == 0 {
+	if args[argNameFaucetAddress] == "" {
 		return cmd.RenderFailedTemplate("Please provide a valid address to receive the faucet amount.")
 	}
 
@@ -32,7 +32,7 @@ func (c *PhoenixCmd) faucetHandler(
 		return cmd.RenderErrorTemplate(err)
 	}
 
-	toAddr := args["address"]
+	toAddr := args[argNameFaucetAddress]
 	receiverAddress, err := utils.TestnetAddressFromString(toAddr)
 	if err != nil {
 		return cmd.RenderErrorTemplate(err)

--- a/internal/engine/command/phoenix/faucet.go
+++ b/internal/engine/command/phoenix/faucet.go
@@ -21,6 +21,7 @@ func (c *PhoenixCmd) faucetHandler(
 		timeSinceLastFaucet := lastFaucet.ElapsedTime()
 		if timeSinceLastFaucet <= c.faucetCooldown {
 			timeToWait := c.faucetCooldown - timeSinceLastFaucet
+
 			return cmd.RenderFailedTemplateF(
 				"You have already used your faucet share. Please try again in %s.",
 				utils.FormatDuration(timeToWait))

--- a/internal/engine/command/phoenix/faucet.go
+++ b/internal/engine/command/phoenix/faucet.go
@@ -10,34 +10,34 @@ func (p *PhoenixCmd) faucetHandler(
 	cmd *command.Command,
 	args map[string]string,
 ) command.CommandResult {
-	if len(args) == 0 {
-		return cmd.RenderFailedTemplate("Invalid wallet address")
-	}
+	// if len(args) == 0 {
+	// 	return cmd.RenderFailedTemplate("Invalid wallet address")
+	// }
 
-	toAddr := args["address"]
-	if len(toAddr) != 43 || toAddr[:3] != "tpc" {
-		return cmd.RenderFailedTemplate("Invalid wallet address")
-	}
+	// toAddr := args["address"]
+	// if len(toAddr) != 43 || toAddr[:3] != "tpc" {
+	// 	return cmd.RenderFailedTemplate("Invalid wallet address")
+	// }
 
-	if !p.db.CanGetFaucet(caller) {
-		return cmd.RenderFailedTemplate("Uh, you used your share of faucets today!")
-	}
+	// if !p.db.CanGetFaucet(caller) {
+	// 	return cmd.RenderFailedTemplate("Uh, you used your share of faucets today!")
+	// }
 
-	txHash, err := p.wallet.TransferTransaction(toAddr, "Phoenix Testnet Pagu PhoenixFaucet", p.faucetAmount)
-	if err != nil {
-		return cmd.RenderErrorTemplate(err)
-	}
+	// txHash, err := p.wallet.TransferTransaction(toAddr, "Pagu Phoenix Faucet", p.faucetAmount)
+	// if err != nil {
+	// 	return cmd.RenderErrorTemplate(err)
+	// }
 
-	if err = p.db.AddFaucet(&entity.PhoenixFaucet{
-		UserID:  caller.ID,
-		Address: toAddr,
-		Amount:  p.faucetAmount,
-		TxHash:  txHash,
-	}); err != nil {
-		return cmd.RenderErrorTemplate(err)
-	}
+	// if err = p.db.AddFaucet(&entity.PhoenixFaucet{
+	// 	UserID:  caller.ID,
+	// 	Address: toAddr,
+	// 	Amount:  p.faucetAmount,
+	// 	TxHash:  txHash,
+	// }); err != nil {
+	// 	return cmd.RenderErrorTemplate(err)
+	// }
 
 	return cmd.RenderResultTemplate(
 		"amount", p.faucetAmount.ToPAC(),
-		"txHash", txHash)
+		"txHash", "txHash")
 }

--- a/internal/engine/command/phoenix/faucet_test.go
+++ b/internal/engine/command/phoenix/faucet_test.go
@@ -42,13 +42,12 @@ func TestFaucet(t *testing.T) {
 			time.Sleep(1 * time.Second)
 
 			// Test cooldown period
-			result := td.phoenixCmd.faucetHandler(caller, td.phoenixCmd.subCmdFaucet, args)
-			assert.False(t, result.Successful)
-			assert.Contains(t, result.Message, "Please try again in 59 minutes")
+			result2 := td.phoenixCmd.faucetHandler(caller, td.phoenixCmd.subCmdFaucet, args)
+			assert.False(t, result2.Successful)
+			assert.Contains(t, result2.Message, "Please try again in 59 minutes")
 		} else {
 			// In case the test wallet is empty
 			assert.Contains(t, result.Message, "insufficient funds")
 		}
-
 	})
 }

--- a/internal/engine/command/phoenix/faucet_test.go
+++ b/internal/engine/command/phoenix/faucet_test.go
@@ -1,0 +1,54 @@
+package phoenix
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pagu-project/pagu/internal/entity"
+	"github.com/pagu-project/pagu/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFaucet(t *testing.T) {
+	td := setup(t)
+
+	caller := &entity.User{DBModel: entity.DBModel{ID: 1}}
+	randAddr := utils.TestnetAddressToString(td.RandAccAddress())
+
+	t.Run("No Address", func(t *testing.T) {
+		args := map[string]string{}
+		result := td.phoenixCmd.faucetHandler(caller, td.phoenixCmd.subCmdFaucet, args)
+		assert.False(t, result.Successful)
+		assert.Contains(t, result.Message, "Please provide a valid address")
+	})
+
+	t.Run("Invalid Address", func(t *testing.T) {
+		args := map[string]string{
+			"address": "invalid-address",
+		}
+		result := td.phoenixCmd.faucetHandler(caller, td.phoenixCmd.subCmdFaucet, args)
+		assert.False(t, result.Successful)
+		assert.Contains(t, result.Message, "invalid separator index")
+	})
+
+	t.Run("Ok", func(t *testing.T) {
+		args := map[string]string{
+			"address": randAddr,
+		}
+		result := td.phoenixCmd.faucetHandler(caller, td.phoenixCmd.subCmdFaucet, args)
+		if result.Successful {
+			assert.Contains(t, result.Message, td.phoenixCmd.faucetAmount.String())
+
+			time.Sleep(1 * time.Second)
+
+			// Test cooldown period
+			result := td.phoenixCmd.faucetHandler(caller, td.phoenixCmd.subCmdFaucet, args)
+			assert.False(t, result.Successful)
+			assert.Contains(t, result.Message, "Please try again in 59 minutes")
+		} else {
+			// In case the test wallet is empty
+			assert.Contains(t, result.Message, "insufficient funds")
+		}
+
+	})
+}

--- a/internal/engine/command/phoenix/health.go
+++ b/internal/engine/command/phoenix/health.go
@@ -5,10 +5,10 @@ import (
 	"github.com/pagu-project/pagu/internal/entity"
 )
 
-func (p *PhoenixCmd) healthHandler(
-	caller *entity.User,
+func (*PhoenixCmd) healthHandler(
+	_ *entity.User,
 	cmd *command.Command,
-	args map[string]string,
+	_ map[string]string,
 ) command.CommandResult {
 	return cmd.RenderFailedTemplate("TODO!")
 }

--- a/internal/engine/command/phoenix/health.go
+++ b/internal/engine/command/phoenix/health.go
@@ -1,0 +1,14 @@
+package phoenix
+
+import (
+	"github.com/pagu-project/pagu/internal/engine/command"
+	"github.com/pagu-project/pagu/internal/entity"
+)
+
+func (p *PhoenixCmd) healthHandler(
+	caller *entity.User,
+	cmd *command.Command,
+	args map[string]string,
+) command.CommandResult {
+	return cmd.RenderFailedTemplate("TODO!")
+}

--- a/internal/engine/command/phoenix/phoenix.gen.go
+++ b/internal/engine/command/phoenix/phoenix.gen.go
@@ -8,16 +8,30 @@ import (
 const argNameFaucetAddress = "address"
 
 type phoenixSubCmds struct {
+	subCmdHealth *command.Command
+	subCmdStatus *command.Command
 	subCmdFaucet *command.Command
 	subCmdWallet *command.Command
 }
 
 func (c *PhoenixCmd) buildSubCmds() *phoenixSubCmds {
+	subCmdHealth := &command.Command{
+		Name:           "health",
+		Help:           "Check the network health status",
+		Handler:        c.healthHandler,
+		ResultTemplate: "Network is {{.Status}}\nCurrent Time: {{.CurrentTime}}\nLast Block Time: {{.LastBlockTime}}\nTime Difference: {{.TimeDiff}}\nLast Block Height: {{.LastBlockHeight}}\n",
+	}
+	subCmdStatus := &command.Command{
+		Name:           "status",
+		Help:           "View network statistics",
+		Handler:        c.statusHandler,
+		ResultTemplate: "Network Name: {{.NetworkName}}\nConnected Peers: {{.ConnectedPeers}}\nValidator Count: {{.ValidatorsCount}}\nAccount Count: {{.AccountsCount}}\nCurrent Block Height: {{.CurrentBlockHeight}}\nTotal Power: {{.TotalPower}} PAC\nTotal Committee Power: {{.TotalCommitteePower}} PAC\nCirculating Supply: {{.CirculatingSupply}} PAC\n\n> Note📝: This info is from a random network node. Non-calculated data may not be consistent.\n",
+	}
 	subCmdFaucet := &command.Command{
 		Name:           "faucet",
-		Help:           "Get tPAC Coins on Phoenix Testnet for Testing your code or project",
+		Help:           "Get tPAC test coins on Phoenix Testnet for testing your project",
 		Handler:        c.faucetHandler,
-		ResultTemplate: "You got {{.amount}} tPAC on Phoenix Testnet!\n\nhttps://phoenix.testnet.pac.network/tx/{{.txHash}}\n",
+		ResultTemplate: "You received {{.amount}} tPAC on Phoenix Testnet!\n\nhttps://phoenix.pacviewer.com/tx/{{.txHash}}\n",
 		Args: []*command.Args{
 			{
 				Name:     "address",
@@ -31,10 +45,12 @@ func (c *PhoenixCmd) buildSubCmds() *phoenixSubCmds {
 		Name:           "wallet",
 		Help:           "Show the faucet wallet balance",
 		Handler:        c.walletHandler,
-		ResultTemplate: "Pagu Phoenix wallet\n\nAddress: {{.address}}\nBalance: {{.balance}}\n",
+		ResultTemplate: "Pagu Phoenix Wallet:\n\nAddress: {{.address}}\nBalance: {{.balance}}\n",
 	}
 
 	return &phoenixSubCmds{
+		subCmdHealth: subCmdHealth,
+		subCmdStatus: subCmdStatus,
 		subCmdFaucet: subCmdFaucet,
 		subCmdWallet: subCmdWallet,
 	}
@@ -42,14 +58,16 @@ func (c *PhoenixCmd) buildSubCmds() *phoenixSubCmds {
 
 func (c *PhoenixCmd) buildPhoenixCommand() *command.Command {
 	phoenixCmd := &command.Command{
-		Emoji:       "🛠️",
+		Emoji:       "🐦",
 		Name:        "phoenix",
-		Help:        "Phoenix Testnet tools and utils for developers",
+		Help:        "Commands for working with Phoenix Testnet",
 		SubCommands: make([]*command.Command, 0),
 	}
 
 	c.phoenixSubCmds = c.buildSubCmds()
 
+	phoenixCmd.AddSubCommand(c.subCmdHealth)
+	phoenixCmd.AddSubCommand(c.subCmdStatus)
 	phoenixCmd.AddSubCommand(c.subCmdFaucet)
 	phoenixCmd.AddSubCommand(c.subCmdWallet)
 

--- a/internal/engine/command/phoenix/phoenix.gen.go
+++ b/internal/engine/command/phoenix/phoenix.gen.go
@@ -25,7 +25,7 @@ func (c *PhoenixCmd) buildSubCmds() *phoenixSubCmds {
 		Name:           "status",
 		Help:           "View network statistics",
 		Handler:        c.statusHandler,
-		ResultTemplate: "Network Name: {{.NetworkName}}\nConnected Peers: {{.ConnectedPeers}}\nValidator Count: {{.ValidatorsCount}}\nAccount Count: {{.AccountsCount}}\nCurrent Block Height: {{.CurrentBlockHeight}}\nTotal Power: {{.TotalPower}} tPAC\nTotal Committee Power: {{.TotalCommitteePower}} tPAC\nCirculating Supply: {{.CirculatingSupply}} tPAC\n\n> Note📝: This info is from a random network node. Some data may not be consistent.\n",
+		ResultTemplate: "Network Name: {{.NetworkName}}\nConnected Peers: {{.ConnectedPeers}}\nValidator Count: {{.ValidatorsCount}}\nAccount Count: {{.AccountsCount}}\nCurrent Block Height: {{.CurrentBlockHeight}}\nTotal Power: {{.TotalPower}} tPAC\nTotal Committee Power: {{.TotalCommitteePower}} tPAC\n\n> Note📝: This info is from a random network node. Some data may not be consistent.\n",
 	}
 	subCmdFaucet := &command.Command{
 		Name:           "faucet",

--- a/internal/engine/command/phoenix/phoenix.gen.go
+++ b/internal/engine/command/phoenix/phoenix.gen.go
@@ -25,7 +25,7 @@ func (c *PhoenixCmd) buildSubCmds() *phoenixSubCmds {
 		Name:           "status",
 		Help:           "View network statistics",
 		Handler:        c.statusHandler,
-		ResultTemplate: "Network Name: {{.NetworkName}}\nConnected Peers: {{.ConnectedPeers}}\nValidator Count: {{.ValidatorsCount}}\nAccount Count: {{.AccountsCount}}\nCurrent Block Height: {{.CurrentBlockHeight}}\nTotal Power: {{.TotalPower}} PAC\nTotal Committee Power: {{.TotalCommitteePower}} PAC\nCirculating Supply: {{.CirculatingSupply}} PAC\n\n> Note📝: This info is from a random network node. Non-calculated data may not be consistent.\n",
+		ResultTemplate: "Network Name: {{.NetworkName}}\nConnected Peers: {{.ConnectedPeers}}\nValidator Count: {{.ValidatorsCount}}\nAccount Count: {{.AccountsCount}}\nCurrent Block Height: {{.CurrentBlockHeight}}\nTotal Power: {{.TotalPower}} tPAC\nTotal Committee Power: {{.TotalCommitteePower}} tPAC\nCirculating Supply: {{.CirculatingSupply}} tPAC\n\n> Note📝: This info is from a random network node. Some data may not be consistent.\n",
 	}
 	subCmdFaucet := &command.Command{
 		Name:           "faucet",

--- a/internal/engine/command/phoenix/phoenix.go
+++ b/internal/engine/command/phoenix/phoenix.go
@@ -2,61 +2,67 @@ package phoenix
 
 import (
 	"context"
-	"log"
+	"time"
 
 	"github.com/pactus-project/pactus/crypto"
+	"github.com/pactus-project/pactus/crypto/ed25519"
+	"github.com/pactus-project/pactus/util/logger"
 	"github.com/pagu-project/pagu/internal/engine/command"
 	"github.com/pagu-project/pagu/internal/entity"
 	"github.com/pagu-project/pagu/internal/repository"
 	"github.com/pagu-project/pagu/pkg/amount"
 	"github.com/pagu-project/pagu/pkg/client"
+	"github.com/pagu-project/pagu/pkg/utils"
 )
 
 type PhoenixCmd struct {
 	*phoenixSubCmds
 
-	ctx           context.Context
-	db            *repository.Database
-	client        client.IClient
-	faucetAmount  amount.Amount
-	faucetAddress string
+	ctx            context.Context
+	db             *repository.Database
+	client         client.IClient
+	privateKey     *ed25519.PrivateKey
+	faucetAddress  crypto.Address
+	faucetAmount   amount.Amount
+	faucetFee      amount.Amount
+	faucetCooldown time.Duration
 }
 
 func NewPhoenixCmd(ctx context.Context, cfg *Config, db *repository.Database,
 ) *PhoenixCmd {
 	client, err := client.NewClient(cfg.Client)
 	if err != nil {
-		log.Fatal("an error occurred on creating client for Phoenix Command", "error", err)
+		logger.Fatal("phoenix: bad client", "error", err)
 	}
 
-	crypto.AddressHRP = "tpc"
-	faucetAddress := cfg.PrivateKey.PublicKeyNative().AccountAddress().String()
-	crypto.AddressHRP = "pc"
-
-	// wlt, err := wallet.New(cfg.Wallet)
-	// if err != nil {
-	// 	log.Fatal("an error occurred on creating wallet for Phoenix Command", "error", err)
-	// }
+	privateKey, err := utils.TestnetPrivateKeyFromString(cfg.PrivateKey)
+	if err != nil {
+		logger.Fatal("phoenix: invalid private key", "error", err)
+	}
+	faucetAddress := privateKey.PublicKeyNative().AccountAddress()
 
 	return &PhoenixCmd{
-		ctx:           ctx,
-		client:        client,
-		db:            db,
-		faucetAddress: faucetAddress,
-		faucetAmount:  cfg.FaucetAmount,
+		ctx:            ctx,
+		client:         client,
+		db:             db,
+		privateKey:     privateKey,
+		faucetAddress:  faucetAddress,
+		faucetAmount:   cfg.FaucetAmount,
+		faucetFee:      cfg.FaucetAmount,
+		faucetCooldown: cfg.FaucetCooldown,
 	}
 }
 
-func (p *PhoenixCmd) GetCommand() *command.Command {
-	cmd := p.buildPhoenixCommand()
+func (c *PhoenixCmd) GetCommand() *command.Command {
+	cmd := c.buildPhoenixCommand()
 	cmd.PlatformIDs = entity.AllPlatformIDs()
 	cmd.TargetFlag = command.TargetMaskAll
 
-	p.subCmdFaucet.PlatformIDs = entity.AllPlatformIDs()
-	p.subCmdFaucet.TargetFlag = command.TargetMaskAll
+	c.subCmdFaucet.PlatformIDs = entity.AllPlatformIDs()
+	c.subCmdFaucet.TargetFlag = command.TargetMaskAll
 
-	p.subCmdWallet.PlatformIDs = entity.AllPlatformIDs()
-	p.subCmdWallet.TargetFlag = command.TargetMaskAll
+	c.subCmdWallet.PlatformIDs = entity.AllPlatformIDs()
+	c.subCmdWallet.TargetFlag = command.TargetMaskAll
 
 	return cmd
 }

--- a/internal/engine/command/phoenix/phoenix.go
+++ b/internal/engine/command/phoenix/phoenix.go
@@ -2,50 +2,61 @@ package phoenix
 
 import (
 	"context"
+	"log"
 
+	"github.com/pactus-project/pactus/crypto"
 	"github.com/pagu-project/pagu/internal/engine/command"
 	"github.com/pagu-project/pagu/internal/entity"
 	"github.com/pagu-project/pagu/internal/repository"
 	"github.com/pagu-project/pagu/pkg/amount"
 	"github.com/pagu-project/pagu/pkg/client"
-	"github.com/pagu-project/pagu/pkg/wallet"
 )
 
 type PhoenixCmd struct {
 	*phoenixSubCmds
 
-	ctx          context.Context
-	wallet       wallet.IWallet
-	db           *repository.Database
-	clientMgr    client.IManager
-	faucetAmount amount.Amount
+	ctx           context.Context
+	db            *repository.Database
+	client        client.IClient
+	faucetAmount  amount.Amount
+	faucetAddress string
 }
 
-func NewPhoenixCmd(ctx context.Context, wlt wallet.IWallet, faucetAmount amount.Amount,
-	clientMgr client.IManager, db *repository.Database,
+func NewPhoenixCmd(ctx context.Context, cfg *Config, db *repository.Database,
 ) *PhoenixCmd {
+	client, err := client.NewClient(cfg.Client)
+	if err != nil {
+		log.Fatal("an error occurred on creating client for Phoenix Command", "error", err)
+	}
+
+	crypto.AddressHRP = "tpc"
+	faucetAddress := cfg.PrivateKey.PublicKeyNative().AccountAddress().String()
+	crypto.AddressHRP = "pc"
+
+	// wlt, err := wallet.New(cfg.Wallet)
+	// if err != nil {
+	// 	log.Fatal("an error occurred on creating wallet for Phoenix Command", "error", err)
+	// }
+
 	return &PhoenixCmd{
-		ctx:          ctx,
-		wallet:       wlt,
-		clientMgr:    clientMgr,
-		db:           db,
-		faucetAmount: faucetAmount,
+		ctx:           ctx,
+		client:        client,
+		db:            db,
+		faucetAddress: faucetAddress,
+		faucetAmount:  cfg.FaucetAmount,
 	}
 }
 
 func (p *PhoenixCmd) GetCommand() *command.Command {
-	middlewareHandler := command.NewMiddlewareHandler(p.db, p.wallet)
-
 	cmd := p.buildPhoenixCommand()
 	cmd.PlatformIDs = entity.AllPlatformIDs()
-	cmd.TargetFlag = command.TargetMaskTestnet
+	cmd.TargetFlag = command.TargetMaskAll
 
-	p.subCmdFaucet.Middlewares = []command.MiddlewareFunc{middlewareHandler.WalletBalance}
 	p.subCmdFaucet.PlatformIDs = entity.AllPlatformIDs()
-	p.subCmdFaucet.TargetFlag = command.TargetMaskTestnet
+	p.subCmdFaucet.TargetFlag = command.TargetMaskAll
 
 	p.subCmdWallet.PlatformIDs = entity.AllPlatformIDs()
-	p.subCmdWallet.TargetFlag = command.TargetMaskTestnet
+	p.subCmdWallet.TargetFlag = command.TargetMaskAll
 
 	return cmd
 }

--- a/internal/engine/command/phoenix/phoenix.yml
+++ b/internal/engine/command/phoenix/phoenix.yml
@@ -1,24 +1,48 @@
 ---
-emoji: 🛠️
+emoji: 🐦
 name: phoenix
-help: Phoenix Testnet tools and utils for developers
+help: Commands for working with Phoenix Testnet
 sub_commands:
-  - name: faucet
-    help: Get tPAC Coins on Phoenix Testnet for Testing your code or project
+  - name: health
+    help: Check the network health status
     result_template: |
-      You got {{.amount}} tPAC on Phoenix Testnet!
+      Network is {{.Status}}
+      Current Time: {{.CurrentTime}}
+      Last Block Time: {{.LastBlockTime}}
+      Time Difference: {{.TimeDiff}}
+      Last Block Height: {{.LastBlockHeight}}
 
-      https://phoenix.testnet.pac.network/tx/{{.txHash}}
+  - name: status
+    help: View network statistics
+    result_template: |
+      Network Name: {{.NetworkName}}
+      Connected Peers: {{.ConnectedPeers}}
+      Validator Count: {{.ValidatorsCount}}
+      Account Count: {{.AccountsCount}}
+      Current Block Height: {{.CurrentBlockHeight}}
+      Total Power: {{.TotalPower}} PAC
+      Total Committee Power: {{.TotalCommitteePower}} PAC
+      Circulating Supply: {{.CirculatingSupply}} PAC
+
+      > Note📝: This info is from a random network node. Non-calculated data may not be consistent.
+
+  - name: faucet
+    help: Get tPAC test coins on Phoenix Testnet for testing your project
+    result_template: |
+      You received {{.amount}} tPAC on Phoenix Testnet!
+
+      https://phoenix.pacviewer.com/tx/{{.txHash}}
     args:
       - name: address
         desc: "Your testnet address [example: tpc1z...]"
         required: true
         type: string
         input_box: Text
+
   - name: wallet
     help: Show the faucet wallet balance
     result_template: |
-      Pagu Phoenix wallet
+      Pagu Phoenix Wallet:
 
       Address: {{.address}}
       Balance: {{.balance}}

--- a/internal/engine/command/phoenix/phoenix.yml
+++ b/internal/engine/command/phoenix/phoenix.yml
@@ -20,11 +20,11 @@ sub_commands:
       Validator Count: {{.ValidatorsCount}}
       Account Count: {{.AccountsCount}}
       Current Block Height: {{.CurrentBlockHeight}}
-      Total Power: {{.TotalPower}} PAC
-      Total Committee Power: {{.TotalCommitteePower}} PAC
-      Circulating Supply: {{.CirculatingSupply}} PAC
+      Total Power: {{.TotalPower}} tPAC
+      Total Committee Power: {{.TotalCommitteePower}} tPAC
+      Circulating Supply: {{.CirculatingSupply}} tPAC
 
-      > Note📝: This info is from a random network node. Non-calculated data may not be consistent.
+      > Note📝: This info is from a random network node. Some data may not be consistent.
 
   - name: faucet
     help: Get tPAC test coins on Phoenix Testnet for testing your project

--- a/internal/engine/command/phoenix/phoenix.yml
+++ b/internal/engine/command/phoenix/phoenix.yml
@@ -22,7 +22,6 @@ sub_commands:
       Current Block Height: {{.CurrentBlockHeight}}
       Total Power: {{.TotalPower}} tPAC
       Total Committee Power: {{.TotalCommitteePower}} tPAC
-      Circulating Supply: {{.CirculatingSupply}} tPAC
 
       > Note📝: This info is from a random network node. Some data may not be consistent.
 

--- a/internal/engine/command/phoenix/phoenix_test.go
+++ b/internal/engine/command/phoenix/phoenix_test.go
@@ -3,9 +3,11 @@ package phoenix
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/pagu-project/pagu/internal/repository"
 	"github.com/pagu-project/pagu/internal/testsuite"
+	"github.com/pagu-project/pagu/pkg/amount"
 )
 
 type testData struct {
@@ -21,11 +23,12 @@ func setup(t *testing.T) *testData {
 	ts := testsuite.NewTestSuite(t)
 
 	testDB := ts.MakeTestDB()
-	_, privateKey := ts.RandEd25519KeyPair()
 	cfg := &Config{
-		Client:       "testnet1.pactus.org:50052",
-		PrivateKey:   privateKey,
-		FaucetAmount: 5,
+		Client:         "testnet1.pactus.org:50052",
+		PrivateKey:     "TSECRET1RZSMS2JGNFLRU26NHNQK3JYTD4KGKLGW4S7SG75CZ057SR7CE8HUSG5MS3Z",
+		FaucetAmount:   amount.Amount(1),
+		FaucetFee:      amount.Amount(0),
+		FaucetCooldown: 1 * time.Hour,
 	}
 
 	phoenixCmd := NewPhoenixCmd(context.Background(), cfg,

--- a/internal/engine/command/phoenix/phoenix_test.go
+++ b/internal/engine/command/phoenix/phoenix_test.go
@@ -1,0 +1,41 @@
+package phoenix
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pagu-project/pagu/internal/repository"
+	"github.com/pagu-project/pagu/internal/testsuite"
+)
+
+type testData struct {
+	*testsuite.TestSuite
+
+	phoenixCmd *PhoenixCmd
+	database   *repository.Database
+}
+
+func setup(t *testing.T) *testData {
+	t.Helper()
+
+	ts := testsuite.NewTestSuite(t)
+
+	testDB := ts.MakeTestDB()
+	_, privateKey := ts.RandEd25519KeyPair()
+	cfg := &Config{
+		Client:       "testnet1.pactus.org:50052",
+		PrivateKey:   privateKey,
+		FaucetAmount: 5,
+	}
+
+	phoenixCmd := NewPhoenixCmd(context.Background(), cfg,
+		testDB)
+
+	_ = phoenixCmd.GetCommand()
+
+	return &testData{
+		TestSuite:  ts,
+		phoenixCmd: phoenixCmd,
+		database:   testDB,
+	}
+}

--- a/internal/engine/command/phoenix/phoenix_test.go
+++ b/internal/engine/command/phoenix/phoenix_test.go
@@ -2,6 +2,7 @@ package phoenix
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -19,13 +20,17 @@ type testData struct {
 
 func setup(t *testing.T) *testData {
 	t.Helper()
-
 	ts := testsuite.NewTestSuite(t)
+
+	faucetSecret := os.Getenv("GITHUB_FAUCET_SECRET")
+	if faucetSecret == "" {
+		faucetSecret = "TSECRET1RZSMS2JGNFLRU26NHNQK3JYTD4KGKLGW4S7SG75CZ057SR7CE8HUSG5MS3Z"
+	}
 
 	testDB := ts.MakeTestDB()
 	cfg := &Config{
 		Client:         "testnet1.pactus.org:50052",
-		PrivateKey:     "TSECRET1RZSMS2JGNFLRU26NHNQK3JYTD4KGKLGW4S7SG75CZ057SR7CE8HUSG5MS3Z",
+		PrivateKey:     faucetSecret,
 		FaucetAmount:   amount.Amount(1),
 		FaucetFee:      amount.Amount(0),
 		FaucetCooldown: 1 * time.Hour,

--- a/internal/engine/command/phoenix/phoenix_test.go
+++ b/internal/engine/command/phoenix/phoenix_test.go
@@ -22,15 +22,15 @@ func setup(t *testing.T) *testData {
 	t.Helper()
 	ts := testsuite.NewTestSuite(t)
 
-	faucetSecret := os.Getenv("GITHUB_FAUCET_SECRET")
-	if faucetSecret == "" {
-		faucetSecret = "TSECRET1RZSMS2JGNFLRU26NHNQK3JYTD4KGKLGW4S7SG75CZ057SR7CE8HUSG5MS3Z"
+	faucetPrivateKey := os.Getenv("GITHUB_FAUCET_SECRET")
+	if faucetPrivateKey == "" {
+		faucetPrivateKey = "TSECRET1RZSMS2JGNFLRU26NHNQK3JYTD4KGKLGW4S7SG75CZ057SR7CE8HUSG5MS3Z"
 	}
 
 	testDB := ts.MakeTestDB()
 	cfg := &Config{
 		Client:         "testnet1.pactus.org:50052",
-		PrivateKey:     faucetSecret,
+		PrivateKey:     faucetPrivateKey,
 		FaucetAmount:   amount.Amount(1),
 		FaucetFee:      amount.Amount(0),
 		FaucetCooldown: 1 * time.Hour,

--- a/internal/engine/command/phoenix/status.go
+++ b/internal/engine/command/phoenix/status.go
@@ -1,0 +1,14 @@
+package phoenix
+
+import (
+	"github.com/pagu-project/pagu/internal/engine/command"
+	"github.com/pagu-project/pagu/internal/entity"
+)
+
+func (p *PhoenixCmd) statusHandler(
+	caller *entity.User,
+	cmd *command.Command,
+	args map[string]string,
+) command.CommandResult {
+	return cmd.RenderFailedTemplate("TODO!")
+}

--- a/internal/engine/command/phoenix/status.go
+++ b/internal/engine/command/phoenix/status.go
@@ -5,10 +5,10 @@ import (
 	"github.com/pagu-project/pagu/internal/entity"
 )
 
-func (p *PhoenixCmd) statusHandler(
-	caller *entity.User,
+func (*PhoenixCmd) statusHandler(
+	_ *entity.User,
 	cmd *command.Command,
-	args map[string]string,
+	_ map[string]string,
 ) command.CommandResult {
 	return cmd.RenderFailedTemplate("TODO!")
 }

--- a/internal/engine/command/phoenix/wallet.go
+++ b/internal/engine/command/phoenix/wallet.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pagu-project/pagu/internal/engine/command"
 	"github.com/pagu-project/pagu/internal/entity"
 	"github.com/pagu-project/pagu/pkg/amount"
+	"github.com/pagu-project/pagu/pkg/utils"
 )
 
 func (p *PhoenixCmd) walletHandler(
@@ -11,12 +12,13 @@ func (p *PhoenixCmd) walletHandler(
 	cmd *command.Command,
 	_ map[string]string,
 ) command.CommandResult {
-	balInt, err := p.client.GetBalance(p.ctx, p.faucetAddress)
+	faucetAddress := utils.TestnetAddressToString(p.faucetAddress)
+	balInt, err := p.client.GetBalance(p.ctx, faucetAddress)
 	if err != nil {
 		return cmd.RenderErrorTemplate(err)
 	}
 
 	return cmd.RenderResultTemplate(
-		"address", p.faucetAddress,
+		"address", faucetAddress,
 		"balance", amount.Amount(balInt))
 }

--- a/internal/engine/command/phoenix/wallet.go
+++ b/internal/engine/command/phoenix/wallet.go
@@ -3,6 +3,7 @@ package phoenix
 import (
 	"github.com/pagu-project/pagu/internal/engine/command"
 	"github.com/pagu-project/pagu/internal/entity"
+	"github.com/pagu-project/pagu/pkg/amount"
 )
 
 func (p *PhoenixCmd) walletHandler(
@@ -10,7 +11,12 @@ func (p *PhoenixCmd) walletHandler(
 	cmd *command.Command,
 	_ map[string]string,
 ) command.CommandResult {
+	balInt, err := p.client.GetBalance(p.ctx, p.faucetAddress)
+	if err != nil {
+		return cmd.RenderErrorTemplate(err)
+	}
+
 	return cmd.RenderResultTemplate(
-		"address", p.wallet.Address(),
-		"balance", p.wallet.Balance())
+		"address", p.faucetAddress,
+		"balance", amount.Amount(balInt))
 }

--- a/internal/engine/command/phoenix/wallet.go
+++ b/internal/engine/command/phoenix/wallet.go
@@ -7,13 +7,13 @@ import (
 	"github.com/pagu-project/pagu/pkg/utils"
 )
 
-func (p *PhoenixCmd) walletHandler(
+func (c *PhoenixCmd) walletHandler(
 	_ *entity.User,
 	cmd *command.Command,
 	_ map[string]string,
 ) command.CommandResult {
-	faucetAddress := utils.TestnetAddressToString(p.faucetAddress)
-	balInt, err := p.client.GetBalance(p.ctx, faucetAddress)
+	faucetAddress := utils.TestnetAddressToString(c.faucetAddress)
+	balInt, err := c.client.GetBalance(c.ctx, faucetAddress)
 	if err != nil {
 		return cmd.RenderErrorTemplate(err)
 	}

--- a/internal/engine/command/phoenix/wallet_test.go
+++ b/internal/engine/command/phoenix/wallet_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/pagu-project/pagu/internal/entity"
+	"github.com/pagu-project/pagu/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,5 +16,5 @@ func TestWallet(t *testing.T) {
 	result := td.phoenixCmd.walletHandler(caller, td.phoenixCmd.subCmdWallet, nil)
 
 	assert.True(t, result.Successful)
-	assert.Contains(t, result.Message, "tpc1r3666ga8venyjykp7ffyy96mccs82uh9ry3d2fk")
+	assert.Contains(t, result.Message, utils.TestnetAddressToString(td.phoenixCmd.faucetAddress))
 }

--- a/internal/engine/command/phoenix/wallet_test.go
+++ b/internal/engine/command/phoenix/wallet_test.go
@@ -14,8 +14,6 @@ func TestWallet(t *testing.T) {
 
 	result := td.phoenixCmd.walletHandler(caller, td.phoenixCmd.subCmdWallet, nil)
 
-	// Verify that calling the `Balance` API works fine.
-	// For security reasons, we cannot use any existing private key in this test.
-	assert.False(t, result.Successful)
-	assert.Contains(t, result.Message, "account not found")
+	assert.True(t, result.Successful)
+	assert.Contains(t, result.Message, "tpc1r3666ga8venyjykp7ffyy96mccs82uh9ry3d2fk")
 }

--- a/internal/engine/command/phoenix/wallet_test.go
+++ b/internal/engine/command/phoenix/wallet_test.go
@@ -1,0 +1,21 @@
+package phoenix
+
+import (
+	"testing"
+
+	"github.com/pagu-project/pagu/internal/entity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWallet(t *testing.T) {
+	td := setup(t)
+
+	caller := &entity.User{DBModel: entity.DBModel{ID: 1}}
+
+	result := td.phoenixCmd.walletHandler(caller, td.phoenixCmd.subCmdWallet, nil)
+
+	// Verify that calling the `Balance` API works fine.
+	// For security reasons, we cannot use any existing private key in this test.
+	assert.False(t, result.Successful)
+	assert.Contains(t, result.Message, "account not found")
+}

--- a/internal/engine/command/voucher/create_test.go
+++ b/internal/engine/command/voucher/create_test.go
@@ -50,7 +50,7 @@ func TestCreateOne(t *testing.T) {
 			"amount":       "100",
 			"valid-months": "12",
 			"recipient":    "Kayhan",
-			"description":  "Testnet node",
+			"description":  "Some descriptions",
 		}
 
 		result := td.voucherCmd.createHandler(caller, td.voucherCmd.subCmdCreate, args)

--- a/internal/engine/command/voucher/voucher.go
+++ b/internal/engine/command/voucher/voucher.go
@@ -31,19 +31,19 @@ func (v *VoucherCmd) GetCommand() *command.Command {
 	cmd.PlatformIDs = entity.AllPlatformIDs()
 	cmd.TargetFlag = command.TargetMaskMainnet | command.TargetMaskModerator
 
-	v.subCmdClaim.PlatformIDs = []entity.PlatformID{entity.PlatformIDDiscord}
+	v.subCmdClaim.PlatformIDs = []entity.PlatformID{entity.PlatformIDDiscord, entity.PlatformIDCLI}
 	v.subCmdClaim.TargetFlag = command.TargetMaskMainnet
 	v.subCmdClaim.Middlewares = []command.MiddlewareFunc{middlewareHandler.WalletBalance}
 
-	v.subCmdCreate.PlatformIDs = []entity.PlatformID{entity.PlatformIDDiscord}
+	v.subCmdCreate.PlatformIDs = []entity.PlatformID{entity.PlatformIDDiscord, entity.PlatformIDCLI}
 	v.subCmdCreate.TargetFlag = command.TargetMaskModerator
 	v.subCmdCreate.Middlewares = []command.MiddlewareFunc{middlewareHandler.OnlyModerator}
 
-	v.subCmdCreateBulk.PlatformIDs = []entity.PlatformID{entity.PlatformIDDiscord}
+	v.subCmdCreateBulk.PlatformIDs = []entity.PlatformID{entity.PlatformIDDiscord, entity.PlatformIDCLI}
 	v.subCmdCreateBulk.TargetFlag = command.TargetMaskModerator
 	v.subCmdCreateBulk.Middlewares = []command.MiddlewareFunc{middlewareHandler.OnlyModerator}
 
-	v.subCmdStatus.PlatformIDs = []entity.PlatformID{entity.PlatformIDDiscord}
+	v.subCmdStatus.PlatformIDs = []entity.PlatformID{entity.PlatformIDDiscord, entity.PlatformIDCLI}
 	v.subCmdStatus.TargetFlag = command.TargetMaskModerator
 	v.subCmdStatus.Middlewares = []command.MiddlewareFunc{middlewareHandler.OnlyModerator}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -128,7 +128,7 @@ func newBotEngine(ctx context.Context,
 	crowdfundCmd := crowdfund.NewCrowdfundCmd(ctx, db, wlt, nowPayments)
 	calculatorCmd := calculator.NewCalculatorCmd(mgr)
 	networkCmd := network.NewNetworkCmd(ctx, mgr)
-	phoenixCmd := phoenix.NewPhoenixCmd(ctx, cfg.Phoenix, mgr, db)
+	phoenixCmd := phoenix.NewPhoenixCmd(ctx, cfg.Phoenix, db)
 	voucherCmd := voucher.NewVoucherCmd(db, wlt, mgr)
 	marketCmd := market.NewMarketCmd(mgr, priceCache)
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -13,12 +13,11 @@ import (
 	"github.com/pagu-project/pagu/internal/engine/command/crowdfund"
 	"github.com/pagu-project/pagu/internal/engine/command/market"
 	"github.com/pagu-project/pagu/internal/engine/command/network"
-	phoenixtestnet "github.com/pagu-project/pagu/internal/engine/command/phoenix"
+	"github.com/pagu-project/pagu/internal/engine/command/phoenix"
 	"github.com/pagu-project/pagu/internal/engine/command/voucher"
 	"github.com/pagu-project/pagu/internal/entity"
 	"github.com/pagu-project/pagu/internal/job"
 	"github.com/pagu-project/pagu/internal/repository"
-	"github.com/pagu-project/pagu/pkg/amount"
 	"github.com/pagu-project/pagu/pkg/cache"
 	"github.com/pagu-project/pagu/pkg/client"
 	"github.com/pagu-project/pagu/pkg/log"
@@ -70,7 +69,7 @@ func NewBotEngine(cfg *config.Config) (*BotEngine, error) {
 		mgr.AddClient(client)
 	}
 
-	wlt, err := wallet.Open(cfg.Wallet)
+	wlt, err := wallet.New(cfg.Wallet)
 	if err != nil {
 		cancel()
 
@@ -108,16 +107,16 @@ func NewBotEngine(cfg *config.Config) (*BotEngine, error) {
 		return nil, err
 	}
 
-	return newBotEngine(ctx, cancel, db, mgr, wlt, nowPayments, cfg.Phoenix.FaucetAmount), nil
+	return newBotEngine(ctx, cancel, cfg, db, mgr, wlt, nowPayments), nil
 }
 
 func newBotEngine(ctx context.Context,
 	cancel context.CancelFunc,
+	cfg *config.Config,
 	db *repository.Database,
 	mgr client.IManager,
 	wlt wallet.IWallet,
 	nowPayments nowpayments.INowPayments,
-	phoenixFaucetAmount amount.Amount,
 ) *BotEngine {
 	// price caching job
 	priceCache := cache.NewBasic[string, entity.Price](10 * time.Second)
@@ -129,7 +128,7 @@ func newBotEngine(ctx context.Context,
 	crowdfundCmd := crowdfund.NewCrowdfundCmd(ctx, db, wlt, nowPayments)
 	calculatorCmd := calculator.NewCalculatorCmd(mgr)
 	networkCmd := network.NewNetworkCmd(ctx, mgr)
-	phoenixCmd := phoenixtestnet.NewPhoenixCmd(ctx, wlt, phoenixFaucetAmount, mgr, db)
+	phoenixCmd := phoenix.NewPhoenixCmd(ctx, cfg.Phoenix, mgr, db)
 	voucherCmd := voucher.NewVoucherCmd(db, wlt, mgr)
 	marketCmd := market.NewMarketCmd(mgr, priceCache)
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pagu-project/pagu/config"
 	"github.com/pagu-project/pagu/internal/engine/command"
+	"github.com/pagu-project/pagu/internal/engine/command/phoenix"
 	"github.com/pagu-project/pagu/internal/testsuite"
 	"github.com/pagu-project/pagu/pkg/client"
 	"github.com/pagu-project/pagu/pkg/nowpayments"
@@ -162,7 +163,11 @@ func TestCheckCommandsAndArgs(t *testing.T) {
 	mockClientManager := client.NewMockIManager(ctrl)
 	mockWallet := wallet.NewMockIWallet(ctrl)
 	mockNowPayments := nowpayments.NewMockINowPayments(ctrl)
-	cfg := &config.Config{}
+	cfg := &config.Config{
+		Phoenix: &phoenix.Config{
+			PrivateKey: "TSECRET1RZSMS2JGNFLRU26NHNQK3JYTD4KGKLGW4S7SG75CZ057SR7CE8HUSG5MS3Z",
+		},
+	}
 	eng := newBotEngine(ctx, cancel, cfg, testDB, mockClientManager, mockWallet, mockNowPayments)
 
 	var checkCommands func(cmds []*command.Command)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pagu-project/pagu/config"
 	"github.com/pagu-project/pagu/internal/engine/command"
 	"github.com/pagu-project/pagu/internal/testsuite"
 	"github.com/pagu-project/pagu/pkg/client"
@@ -161,7 +162,8 @@ func TestCheckCommandsAndArgs(t *testing.T) {
 	mockClientManager := client.NewMockIManager(ctrl)
 	mockWallet := wallet.NewMockIWallet(ctrl)
 	mockNowPayments := nowpayments.NewMockINowPayments(ctrl)
-	eng := newBotEngine(ctx, cancel, testDB, mockClientManager, mockWallet, mockNowPayments, 5)
+	cfg := &config.Config{}
+	eng := newBotEngine(ctx, cancel, cfg, testDB, mockClientManager, mockWallet, mockNowPayments)
 
 	var checkCommands func(cmds []*command.Command)
 

--- a/internal/platforms/discord/discord.go
+++ b/internal/platforms/discord/discord.go
@@ -93,11 +93,6 @@ func (bot *Bot) registerCommands() error {
 				continue
 			}
 
-		case config.BotNamePaguTestnet:
-			if !utils.IsFlagSet(cmd.TargetFlag, command.TargetMaskTestnet) {
-				continue
-			}
-
 		case config.BotNamePaguModerator:
 			if !utils.IsFlagSet(cmd.TargetFlag, command.TargetMaskModerator) {
 				continue
@@ -122,11 +117,6 @@ func (bot *Bot) registerCommands() error {
 				switch bot.target {
 				case config.BotNamePaguMainnet:
 					if !utils.IsFlagSet(subCmd.TargetFlag, command.TargetMaskMainnet) {
-						continue
-					}
-
-				case config.BotNamePaguTestnet:
-					if !utils.IsFlagSet(subCmd.TargetFlag, command.TargetMaskTestnet) {
 						continue
 					}
 

--- a/internal/platforms/telegram/telegram.go
+++ b/internal/platforms/telegram/telegram.go
@@ -106,11 +106,6 @@ func (bot *Bot) registerCommands() error {
 				continue
 			}
 
-		case config.BotNamePaguTestnet:
-			if !utils.IsFlagSet(cmd.TargetFlag, command.TargetMaskTestnet) {
-				continue
-			}
-
 		case config.BotNamePaguModerator:
 			if !utils.IsFlagSet(cmd.TargetFlag, command.TargetMaskModerator) {
 				continue
@@ -134,11 +129,6 @@ func (bot *Bot) registerCommands() error {
 				switch bot.target {
 				case config.BotNamePaguMainnet:
 					if !utils.IsFlagSet(subCmd.TargetFlag, command.TargetMaskMainnet) {
-						continue
-					}
-
-				case config.BotNamePaguTestnet:
-					if !utils.IsFlagSet(subCmd.TargetFlag, command.TargetMaskTestnet) {
 						continue
 					}
 

--- a/internal/repository/database.go
+++ b/internal/repository/database.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 type Database struct {
@@ -24,12 +25,15 @@ func NewDB(path string) (*Database, error) {
 
 	var db *gorm.DB
 	var err error
+	conf := &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	}
 
 	switch dbType {
 	case "mysql":
-		db, err = gorm.Open(mysql.Open(connStr), &gorm.Config{})
+		db, err = gorm.Open(mysql.Open(connStr), conf)
 	case "sqlite":
-		db, err = gorm.Open(sqlite.Open(connStr), &gorm.Config{})
+		db, err = gorm.Open(sqlite.Open(connStr), conf)
 	default:
 		return nil, errors.New("unsupported database type: " + dbType)
 	}

--- a/internal/repository/faucet.go
+++ b/internal/repository/faucet.go
@@ -1,8 +1,6 @@
 package repository
 
 import (
-	"time"
-
 	"github.com/pagu-project/pagu/internal/entity"
 )
 
@@ -17,16 +15,15 @@ func (db *Database) AddFaucet(f *entity.PhoenixFaucet) error {
 	return nil
 }
 
-func (db *Database) CanGetFaucet(user *entity.User) bool {
-	var lastFaucet entity.PhoenixFaucet
-	err := db.gormDB.Model(&entity.PhoenixFaucet{}).Where("user_id = ?", user.ID).Order("id DESC").First(&lastFaucet).Error
-	if err != nil {
-		return true
+func (db *Database) GetLastFaucet(user *entity.User) (*entity.PhoenixFaucet, error) {
+	var lastFaucet *entity.PhoenixFaucet
+	tx := db.gormDB.Model(&entity.PhoenixFaucet{}).Where("user_id = ?", user.ID).Order("id DESC").First(&lastFaucet)
+
+	if tx.Error != nil {
+		return nil, ReadError{
+			Message: tx.Error.Error(),
+		}
 	}
 
-	if lastFaucet.ElapsedTime() > 24*time.Hour {
-		return true
-	}
-
-	return false
+	return lastFaucet, nil
 }

--- a/internal/testsuite/testsuite.go
+++ b/internal/testsuite/testsuite.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pactus-project/pactus/crypto/bls"
+	"github.com/pactus-project/pactus/crypto/ed25519"
 	"github.com/pagu-project/pagu/internal/repository"
 	"github.com/pagu-project/pagu/pkg/amount"
 )
@@ -224,4 +226,28 @@ func (*TestSuite) DecodingHex(in string) []byte {
 	}
 
 	return d
+}
+
+// RandBLSKeyPair generates a random BLS key pair for testing purposes.
+func (ts *TestSuite) RandBLSKeyPair() (*bls.PublicKey, *bls.PrivateKey) {
+	buf := make([]byte, bls.PrivateKeySize)
+	_, _ = ts.Rand.Read(buf)
+
+	prv, _ := bls.PrivateKeyFromBytes(buf)
+	pub := prv.PublicKeyNative()
+
+	return pub, prv
+}
+
+// RandEd25519KeyPair generates a random Ed25519 key pair for testing purposes.
+func (ts *TestSuite) RandEd25519KeyPair() (*ed25519.PublicKey, *ed25519.PrivateKey) {
+	buf := make([]byte, ed25519.PrivateKeySize)
+	_, err := ts.Rand.Read(buf)
+	if err != nil {
+		panic(err)
+	}
+	prv, _ := ed25519.PrivateKeyFromBytes(buf)
+	pub := prv.PublicKeyNative()
+
+	return pub, prv
 }

--- a/internal/testsuite/testsuite.go
+++ b/internal/testsuite/testsuite.go
@@ -7,8 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pactus-project/pactus/crypto/bls"
-	"github.com/pactus-project/pactus/crypto/ed25519"
+	"github.com/pactus-project/pactus/crypto"
 	"github.com/pagu-project/pagu/internal/repository"
 	"github.com/pagu-project/pagu/pkg/amount"
 )
@@ -228,26 +227,7 @@ func (*TestSuite) DecodingHex(in string) []byte {
 	return d
 }
 
-// RandBLSKeyPair generates a random BLS key pair for testing purposes.
-func (ts *TestSuite) RandBLSKeyPair() (*bls.PublicKey, *bls.PrivateKey) {
-	buf := make([]byte, bls.PrivateKeySize)
-	_, _ = ts.Rand.Read(buf)
-
-	prv, _ := bls.PrivateKeyFromBytes(buf)
-	pub := prv.PublicKeyNative()
-
-	return pub, prv
-}
-
-// RandEd25519KeyPair generates a random Ed25519 key pair for testing purposes.
-func (ts *TestSuite) RandEd25519KeyPair() (*ed25519.PublicKey, *ed25519.PrivateKey) {
-	buf := make([]byte, ed25519.PrivateKeySize)
-	_, err := ts.Rand.Read(buf)
-	if err != nil {
-		panic(err)
-	}
-	prv, _ := ed25519.PrivateKeyFromBytes(buf)
-	pub := prv.PublicKeyNative()
-
-	return pub, prv
+// RandAccAddress generates a random account address for testing purposes.
+func (ts *TestSuite) RandAccAddress() crypto.Address {
+	return crypto.NewAddress(crypto.AddressTypeEd25519Account, ts.RandBytes(20))
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -172,9 +172,9 @@ func (c *Client) GetFee(ctx context.Context, amt int64) (int64, error) {
 }
 
 func (c *Client) BroadcastTransaction(ctx context.Context, trxData []byte) (string, error) {
-	SignedRawTransaction := hex.EncodeToString(trxData)
+	signedRawTransaction := hex.EncodeToString(trxData)
 	res, err := c.transactionClient.BroadcastTransaction(ctx, &pactus.BroadcastTransactionRequest{
-		SignedRawTransaction: SignedRawTransaction,
+		SignedRawTransaction: signedRawTransaction,
 	})
 	if err != nil {
 		return "", err

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/hex"
 
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/pagu-project/pagu/pkg/log"
@@ -168,6 +169,18 @@ func (c *Client) GetFee(ctx context.Context, amt int64) (int64, error) {
 	}
 
 	return res.Fee, nil
+}
+
+func (c *Client) BroadcastTransaction(ctx context.Context, trxData []byte) (string, error) {
+	SignedRawTransaction := hex.EncodeToString(trxData)
+	res, err := c.transactionClient.BroadcastTransaction(ctx, &pactus.BroadcastTransactionRequest{
+		SignedRawTransaction: SignedRawTransaction,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return res.Id, nil
 }
 
 func (c *Client) Close() error {

--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -15,6 +15,7 @@ type IClient interface {
 	GetValidatorInfo(context.Context, string) (*pactus.GetValidatorResponse, error)
 	GetValidatorInfoByNumber(context.Context, int32) (*pactus.GetValidatorResponse, error)
 	GetTransactionData(context.Context, string) (*pactus.GetTransactionResponse, error)
+	BroadcastTransaction(context.Context, []byte) (string, error)
 	GetBalance(context.Context, string) (int64, error)
 	GetFee(context.Context, int64) (int64, error)
 	Close() error

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -41,6 +41,21 @@ func (m *MockIClient) EXPECT() *MockIClientMockRecorder {
 	return m.recorder
 }
 
+// BroadcastTransaction mocks base method.
+func (m *MockIClient) BroadcastTransaction(arg0 context.Context, arg1 []byte) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BroadcastTransaction", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BroadcastTransaction indicates an expected call of BroadcastTransaction.
+func (mr *MockIClientMockRecorder) BroadcastTransaction(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BroadcastTransaction", reflect.TypeOf((*MockIClient)(nil).BroadcastTransaction), arg0, arg1)
+}
+
 // Close mocks base method.
 func (m *MockIClient) Close() error {
 	m.ctrl.T.Helper()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -131,12 +131,13 @@ func TestnetAddressToString(addr crypto.Address) string {
 	return str
 }
 
-// Helper function to format duration into a human-readable string
+// FormatDuration formats the duration into a human-readable string.
 func FormatDuration(d time.Duration) string {
 	hours := int(d.Hours())
 	minutes := int(d.Minutes()) % 60
 	if hours > 0 {
 		return fmt.Sprintf("%d hours and %d minutes", hours, minutes)
 	}
+
 	return fmt.Sprintf("%d minutes", minutes)
 }

--- a/pkg/wallet/config.go
+++ b/pkg/wallet/config.go
@@ -7,5 +7,4 @@ type Config struct {
 	Path     string        `yaml:"path"`
 	Password string        `yaml:"password"`
 	Fee      amount.Amount `yaml:"fee"`
-	Network  string        `yaml:"network"`
 }

--- a/pkg/wallet/config.go
+++ b/pkg/wallet/config.go
@@ -1,0 +1,11 @@
+package wallet
+
+import "github.com/pagu-project/pagu/pkg/amount"
+
+type Config struct {
+	Address  string        `yaml:"address"`
+	Path     string        `yaml:"path"`
+	Password string        `yaml:"password"`
+	Fee      amount.Amount `yaml:"fee"`
+	Network  string        `yaml:"network"`
+}

--- a/pkg/wallet/interface.go
+++ b/pkg/wallet/interface.go
@@ -3,7 +3,7 @@ package wallet
 import "github.com/pagu-project/pagu/pkg/amount"
 
 type IWallet interface {
-	Balance() int64
+	Balance() amount.Amount
 	Address() string
 	TransferTransaction(toAddress, memo string, amt amount.Amount) (string, error)
 	BondTransaction(pubKey, toAddress, memo string, amt amount.Amount) (string, error)

--- a/pkg/wallet/mock.go
+++ b/pkg/wallet/mock.go
@@ -55,10 +55,10 @@ func (mr *MockIWalletMockRecorder) Address() *gomock.Call {
 }
 
 // Balance mocks base method.
-func (m *MockIWallet) Balance() int64 {
+func (m *MockIWallet) Balance() amount.Amount {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Balance")
-	ret0, _ := ret[0].(int64)
+	ret0, _ := ret[0].(amount.Amount)
 	return ret0
 }
 

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -2,7 +2,6 @@ package wallet
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pactus-project/pactus/genesis"
 	"github.com/pactus-project/pactus/wallet"
@@ -13,11 +12,9 @@ import (
 type Wallet struct {
 	*wallet.Wallet
 
-	address   string
-	password  string
-	fee       amount.Amount
-	chainType genesis.ChainType
-	server    string
+	address  string
+	password string
+	fee      amount.Amount
 }
 
 func New(cfg *Config) (*Wallet, error) {
@@ -26,17 +23,11 @@ func New(cfg *Config) (*Wallet, error) {
 		return nil, err
 	}
 
-	chainType := genesis.Mainnet
-	if strings.ToLower(cfg.Network) == "testnet" {
-		chainType = genesis.Testnet
-	}
-
 	return &Wallet{
-		Wallet:    wlt,
-		address:   cfg.Address,
-		password:  cfg.Password,
-		fee:       cfg.Fee,
-		chainType: chainType,
+		Wallet:   wlt,
+		address:  cfg.Address,
+		password: cfg.Password,
+		fee:      cfg.Fee,
 	}, nil
 }
 


### PR DESCRIPTION
## Description

This PR includes the following changes:  

- Removes the Pagu Testnet Bot.  
- Moves the config for the Phoenix command into the `phoenix` package.  
- Uses a raw private key for signing Faucet transactions.  
- Removes the need for a Testnet wallet and purely relies on a private key for signing Testnet transactions.  

## Related Issue

- Partially Fixes #201

## Types of changes
- [x] Bug fix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (corrections, enhancements, or additions to documentation)
- [ ] Other (please describe):
