### PR TITLE
fix: avoid mapping moderator commands in discord bot

### DIFF
--- a/internal/engine/command/crowdfund/crowdfund.gen.go
+++ b/internal/engine/command/crowdfund/crowdfund.gen.go
@@ -32,7 +32,6 @@ func (c *CrowdfundCmd) buildSubCmds() *crowdfundSubCmds {
 		TargetBotIDs: []entity.BotID{
 			entity.BotID_Moderator,
 			entity.BotID_CLI,
-			entity.BotID_Moderator,
 		},
 		Args: []*command.Args{
 			{
@@ -63,7 +62,6 @@ func (c *CrowdfundCmd) buildSubCmds() *crowdfundSubCmds {
 		TargetBotIDs: []entity.BotID{
 			entity.BotID_Moderator,
 			entity.BotID_CLI,
-			entity.BotID_Moderator,
 		},
 	}
 	subCmdReport := &command.Command{

--- a/internal/engine/command/crowdfund/crowdfund.yml
+++ b/internal/engine/command/crowdfund/crowdfund.yml
@@ -4,7 +4,7 @@ name: crowdfund
 help: Commands for managing crowdfunding campaigns
 sub_commands:
   - name: create
-    target_bot_ids: [Moderator, CLI, Moderator]
+    target_bot_ids: [Moderator, CLI]
     help: Create a new crowdfunding campaign
     result_template: |
       Crowdfund campaign '{{.campaign.Title}}' created successfully with {{ .campaign.Packages | len }} packages
@@ -22,7 +22,7 @@ sub_commands:
         input_box: MultilineText
         optional: false
   - name: disable
-    target_bot_ids: [Moderator, CLI, Moderator]
+    target_bot_ids: [Moderator, CLI]
     help: Disable an existing crowdfunding campaign
   - name: report
     help: View reports of a crowdfunding campaign

--- a/internal/engine/command/voucher/voucher.gen.go
+++ b/internal/engine/command/voucher/voucher.gen.go
@@ -56,7 +56,6 @@ func (c *VoucherCmd) buildSubCmds() *voucherSubCmds {
 		Handler:        c.createHandler,
 		ResultTemplate: "Voucher created successfully!\nCode: {{.voucher.Code}}\n",
 		TargetBotIDs: []entity.BotID{
-			entity.BotID_Discord,
 			entity.BotID_CLI,
 			entity.BotID_Moderator,
 		},
@@ -93,7 +92,6 @@ func (c *VoucherCmd) buildSubCmds() *voucherSubCmds {
 		Handler:        c.createBulkHandler,
 		ResultTemplate: "Vouchers created successfully!\n",
 		TargetBotIDs: []entity.BotID{
-			entity.BotID_Discord,
 			entity.BotID_CLI,
 			entity.BotID_Moderator,
 		},
@@ -118,7 +116,6 @@ func (c *VoucherCmd) buildSubCmds() *voucherSubCmds {
 		Handler:        c.statusHandler,
 		ResultTemplate: "Code: {{.voucher.Code}}\nAmount: {{.voucher.Amount}}\nExpire At: {{.expireAt}}\nRecipient: {{.voucher.Recipient}}\nDescription: {{.voucher.Desc}}\nClaimed: {{.isClaimed}}\nTx Link: {{.txLink}}\n",
 		TargetBotIDs: []entity.BotID{
-			entity.BotID_Discord,
 			entity.BotID_CLI,
 			entity.BotID_Moderator,
 		},

--- a/internal/engine/command/voucher/voucher.yml
+++ b/internal/engine/command/voucher/voucher.yml
@@ -20,7 +20,7 @@ sub_commands:
         input_box: Text
         optional: false
   - name: create
-    target_bot_ids: [Discord, CLI, Moderator]
+    target_bot_ids: [CLI, Moderator]
     help: Generate a single voucher code
     result_template: |
       Voucher created successfully!
@@ -43,7 +43,7 @@ sub_commands:
         input_box: Text
         optional: true
   - name: create-bulk
-    target_bot_ids: [Discord, CLI, Moderator]
+    target_bot_ids: [CLI, Moderator]
     help: Generate multiple voucher codes by importing a file
     result_template: |
       Vouchers created successfully!
@@ -57,7 +57,7 @@ sub_commands:
         input_box: Toggle
         optional: false
   - name: status
-    target_bot_ids: [Discord, CLI, Moderator]
+    target_bot_ids: [CLI, Moderator]
     help: View the status of vouchers or a specific voucher
     result_template: |
       Code: {{.voucher.Code}}


### PR DESCRIPTION
## Description
- Moderator commands shouldn't be in any other bots than moderator bot.
- Some bot IDs were duplicated in YML files

## Related Issue
https://github.com/pagu-project/pagu/issues/229

## Types of changes
- [x] Bug fix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (corrections, enhancements, or additions to documentation)
- [ ] Other (please describe):
