### PR TITLE
fix(discord): put required option before non-required ones

### DIFF
--- a/internal/engine/command/crowdfund/crowdfund.gen.go
+++ b/internal/engine/command/crowdfund/crowdfund.gen.go
@@ -10,10 +10,10 @@ const (
 	argNameCreateTitle     = "title"
 	argNameCreateDesc      = "desc"
 	argNameCreatePackages  = "packages"
+	argNameEditDisable     = "disable"
 	argNameEditTitle       = "title"
 	argNameEditDesc        = "desc"
 	argNameEditPackages    = "packages"
-	argNameEditDisable     = "disable"
 	argNamePurchasePackage = "package"
 	argNameClaimAddress    = "address"
 )
@@ -69,6 +69,12 @@ func (c *CrowdfundCmd) buildSubCmds() *crowdfundSubCmds {
 		},
 		Args: []*command.Args{
 			{
+				Name:     "disable",
+				Desc:     "Disable the current active campaign",
+				InputBox: command.InputBoxToggle,
+				Optional: false,
+			},
+			{
 				Name:     "title",
 				Desc:     "The title of this crowdfunding campaign",
 				InputBox: command.InputBoxText,
@@ -85,12 +91,6 @@ func (c *CrowdfundCmd) buildSubCmds() *crowdfundSubCmds {
 				Desc:     "The packages for this campaign in JSON format",
 				InputBox: command.InputBoxMultilineText,
 				Optional: true,
-			},
-			{
-				Name:     "disable",
-				Desc:     "Disable the current active campaign",
-				InputBox: command.InputBoxToggle,
-				Optional: false,
 			},
 		},
 	}

--- a/internal/engine/command/crowdfund/crowdfund.yml
+++ b/internal/engine/command/crowdfund/crowdfund.yml
@@ -28,6 +28,10 @@ sub_commands:
     result_template: |
       Crowdfund campaign '{{.campaign.Title}}' updated successfully with {{ .campaign.Packages | len }} packages
     args:
+    - name: disable
+      desc: Disable the current active campaign
+      input_box: Toggle
+      optional: false
     - name: title
       desc: The title of this crowdfunding campaign
       input_box: Text
@@ -40,10 +44,6 @@ sub_commands:
       desc: The packages for this campaign in JSON format
       input_box: MultilineText
       optional: true
-    - name: disable
-      desc: Disable the current active campaign
-      input_box: Toggle
-      optional: false
 
   - name: report
     help: View reports of a crowdfunding campaign


### PR DESCRIPTION
## Description  

We received an error from Discord stating:  
```
Required options must be placed before non-required options  
```  

This PR ensures that required options are placed before non-required ones in the `crowdfunding/edit` command.  

## Types of changes
- [x] Bug fix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (corrections, enhancements, or additions to documentation)
- [ ] Other (please describe):
