### PR TITLE
chore: update golangci linters

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: "stable"
 
-      - name: golangci-lint
-        run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-          make check
+      - name: Check linting and formatting
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.2.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,12 @@
+version: "2"
 linters:
   enable:
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
     - asasalint
     - asciicheck
     - bidichk
     - bodyclose
     - contextcheck
+    - copyloopvar
     - decorder
     - dogsled
     - dupword
@@ -19,18 +15,13 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - copyloopvar
     - forbidigo
-    - gci
     - gocheckcompilerdirectives
     - gocognit
     - gocritic
     - gocyclo
     - godot
-    - gofmt
-    - gofumpt
     - goheader
-    - goimports
     - gomoddirectives
     - gomodguard
     - goprintffuncname
@@ -60,175 +51,165 @@ linters:
     - revive
     - rowserrcheck
     - sqlclosecheck
-    - stylecheck
+    - staticcheck
     - tagalign
     - tagliatelle
-    - usetesting
     - testableexamples
     - thelper
     - tparallel
     - unconvert
     - unparam
     - usestdlibvars
+    - usetesting
+    - varnamelen
     - wastedassign
     - whitespace
     - zerologlint
-    - varnamelen
-
-linters-settings:
-  gosimple:
-    checks: ["all"]
-
-  revive:
-    enable-all-rules: true
-    rules:
-      - name: "exported"
-        disabled: true
-
-      - name: package-comments
-        disabled: true
-
-      - name: "add-constant"
-        disabled: true
-
-      - name: "line-length-limit"
-        disabled: true
-
-      - name: "cognitive-complexity"
-        disabled: true
-
-      - name: "function-length"
-        disabled: true
-
-      - name: "cyclomatic"
-        disabled: true
-
-      - name: "unchecked-type-assertion"
-        disabled: true
-
-      - name: max-public-structs
-        disabled: true
-
-      - name: "flag-parameter"
-        disabled: true
-
-      - name: "deep-exit"
-        disabled: true
-
-      - name: "get-return"
-        disabled: true
-
-      - name: "confusing-naming"
-        disabled: true
-
-      - name: "function-result-limit"
-        disabled: true
-
-      - name: "import-shadowing"
-        disabled: true
-
-      - name: redefines-builtin-id
-        disabled: true
-
-      - name: unhandled-error
-        arguments:
-          - "fmt.Printf"
-          - "fmt.Println"
-          - "fmt.Fprintf"
-          - "strings.Builder.WriteString"
-          - "strings.Builder.WriteRune"
-          - "strings.Builder.WriteByte"
-          - "bytes.Buffer.Write"
-          - "bytes.Buffer.WriteString"
-
-  gosec:
-    excludes:
-      - G304
-      - G204
-      - G115
-
-  stylecheck:
-    # ST1000: at least one file in a package should have a package comment
-    checks: ["all", "-ST1000"]
-
-  staticcheck:
-    # SA1019: xyz is deprecated
-    checks: ["all", "-SA1019"]
-
-  govet:
-    enable-all: true
-    disable: ["fieldalignment"]
-
-    settings:
-      shadow:
-        strict: true
-
-  predeclared:
-    # Comma-separated list of predeclared identifiers to not report on.
-    # Default: ""
-    ignore: "len, min, max"
-    # Include method names and field names (i.e., qualified names) in checks.
-    # Default: false
-    q: true
-
-  tagliatelle:
-    # Check the struct tag name case.
-    case:
-      use-field-name: false
+  settings:
+    gocritic:
+      disabled-checks:
+        - ifElseChain
+        - unnamedResult
+        - importShadow
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+    gosec:
+      excludes:
+        - G304
+        - G204
+        - G115
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+      settings:
+        shadow:
+          strict: true
+    nestif:
+      min-complexity: 6
+    predeclared:
+      ignore:
+        - len
+        - ' min'
+        - ' max'
+      qualified-name: true
+    revive:
+      enable-all-rules: true
       rules:
-        json: snake
-        yaml: snake
+        - name: exported
+          disabled: true
+        - name: package-comments
+          disabled: true
+        - name: add-constant
+          disabled: true
+        - name: line-length-limit
+          disabled: true
+        - name: cognitive-complexity
+          disabled: true
+        - name: function-length
+          disabled: true
+        - name: cyclomatic
+          disabled: true
+        - name: unchecked-type-assertion
+          disabled: true
+        - name: max-public-structs
+          disabled: true
+        - name: flag-parameter
+          disabled: true
+        - name: deep-exit
+          disabled: true
+        - name: get-return
+          disabled: true
+        - name: confusing-naming
+          disabled: true
+        - name: function-result-limit
+          disabled: true
+        - name: import-shadowing
+          disabled: true
+        - name: redefines-builtin-id
+          disabled: true
+        - name: unhandled-error
+          arguments:
+            - fmt.Printf
+            - fmt.Println
+            - fmt.Fprintf
+            - strings.Builder.WriteString
+            - strings.Builder.WriteRune
+            - strings.Builder.WriteByte
+            - bytes.Buffer.Write
+            - bytes.Buffer.WriteString
+    staticcheck:
+      checks:
+        - all
+        - -SA1019
+        - -ST1000
+        - -QF1008
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+          yaml: snake
+        use-field-name: false
+    varnamelen:
+      ignore-names:
+        - ok
+        - ip
+        - "no"
+        - tt
+        - i
+        - j
+        - l
+        - h
+        - il
+        - r
+        - w
+        - db
+        - tx
+      ignore-decls:
+        - wg sync.WaitGroup
+        - ts *testsuite.TestSuite
+        - td *testData
+        - ma multiaddr.Multiaddr
+        - db *leveldb.DB
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - forbidigo
+          - gocognit
+          - maintidx
+          - nestif
+        path: _test.go
+      - path: (.+)\.go$
+        text: 'shadow: declaration of "err" shadows'
+      - path: (.+)\.go$
+        text: 'builtinShadow: shadowing of predeclared identifier: min'
+      - path: (.+)\.go$
+        text: 'builtinShadow: shadowing of predeclared identifier: max'
+      - path: (.+)\.go$
+        text: 'builtinShadow: shadowing of predeclared identifier: len'
 
-  gocritic:
-    disabled-checks:
-      - ifElseChain
-      - unnamedResult
-      - importShadow
-    enabled-tags:
-      - diagnostic
-      - style
-      - performance
+      - linters:
+          - revive
+        path: 'util/*'
+        text: 'var-naming: avoid meaningless package names'
 
-  nestif:
-    # Minimal complexity of if statements to report.
-    # Default: 5
-    min-complexity: 6
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
-  varnamelen:
-    ignore-names:
-      - ok
-      - ip
-      - no
-      - tt # table tests
-      - i # for simple loops
-      - j # for simple loops
-      - l
-      - h
-      - il
-      - r # reader
-      - w # writer
-      - db # database
-      - tx # transaction
-
-    ignore-decls:
-      - wg sync.WaitGroup
-      - ts *testsuite.TestSuite
-      - td *testData
-      - ma multiaddr.Multiaddr
-      - db *leveldb.DB
-
-issues:
-  exclude-use-default: false
-  exclude-rules:
-    - path: _test.go
-      linters:
-        - maintidx
-        - nestif
-        - gocognit
-        - forbidigo
-
-  exclude:
-    - 'shadow: declaration of "err" shadows'
-    - 'builtinShadow: shadowing of predeclared identifier: min'
-    - 'builtinShadow: shadowing of predeclared identifier: max'
-    - 'builtinShadow: shadowing of predeclared identifier: len'
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ devtools:
 	@echo "Installing devtools"
 	go install golang.org/x/tools/cmd/goimports@latest
 	go install mvdan.cc/gofumpt@latest
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	go install go.uber.org/mock/mockgen@latest
 	go install github.com/bufbuild/buf/cmd/buf@latest
 


### PR DESCRIPTION
## Description

This PR updates the [Golangci](https://golangci-lint.run/) to version 2.
